### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,4 @@ version: 1
 builder:
   configs:
     - platform: ios
-      documentation_targets: [secp256k1, secp256k1_implementation]
+      documentation_targets: [secp256k1]


### PR DESCRIPTION
Documentation generation fails due to: `error: The workspace named "checkout" does not contain a scheme named "secp256k1_implementation". The "-list" option can be used to find the names of the schemes in the workspace.`

This should fix it!