### PR TITLE
Sign and verify hashed data

### DIFF
--- a/Sources/implementation/Digests.swift
+++ b/Sources/implementation/Digests.swift
@@ -31,11 +31,11 @@
 
 import Foundation
 
-// MARK: - SHA32BytesDigest + DigestPrivate
+// MARK: - Hash32BytesDigest + DigestPrivate
 
-public typealias SHA256Digest = SHA32BytesDigest
+public typealias SHA256Digest = Hash32BytesDigest
 
-public struct SHA32BytesDigest: Digest {
+public struct Hash32BytesDigest: Digest {
     let bytes: (UInt64, UInt64, UInt64, UInt64)
 
     public init(_ output: [UInt8]) {

--- a/Sources/implementation/Digests.swift
+++ b/Sources/implementation/Digests.swift
@@ -31,11 +31,22 @@
 
 import Foundation
 
-// MARK: - SHA256Digest + DigestPrivate
+// MARK: - SHA32BytesDigest + DigestPrivate
 
-public struct SHA256Digest: Digest {
+public typealias SHA256Digest = SHA32BytesDigest
+
+public struct SHA32BytesDigest: Digest {
     let bytes: (UInt64, UInt64, UInt64, UInt64)
 
+    public init(_ output: [UInt8]) {
+        let first = output[0..<8].withUnsafeBytes { $0.load(as: UInt64.self) }
+        let second = output[8..<16].withUnsafeBytes { $0.load(as: UInt64.self) }
+        let third = output[16..<24].withUnsafeBytes { $0.load(as: UInt64.self) }
+        let forth = output[24..<32].withUnsafeBytes { $0.load(as: UInt64.self) }
+        
+        bytes = (first, second, third, forth)
+    }
+    
     public static var byteCount: Int {
         get { 32 }
 

--- a/Sources/implementation/ECDSA.swift
+++ b/Sources/implementation/ECDSA.swift
@@ -152,13 +152,7 @@ extension secp256k1.Signing.ECDSASigner: DigestSigner, Signer {
     /// - Returns: The ECDSA Signature.
     /// - Throws: If there is a failure producing the signature
     public func signature<D: Digest>(for digest: D) throws -> secp256k1.Signing.ECDSASignature {
-        var signature = secp256k1_ecdsa_signature()
-
-        guard secp256k1_ecdsa_sign(secp256k1.Context.raw, &signature, Array(digest), Array(signingKey.rawRepresentation), nil, nil).boolValue else {
-            throw secp256k1Error.underlyingCryptoError
-        }
-
-        return try secp256k1.Signing.ECDSASignature(signature.dataValue)
+        try signature(hash: Array(digest))
     }
 
     /// Generates an ECDSA signature over the secp256k1 elliptic curve.
@@ -169,6 +163,22 @@ extension secp256k1.Signing.ECDSASigner: DigestSigner, Signer {
     /// - Throws: If there is a failure producing the signature.
     public func signature<D: DataProtocol>(for data: D) throws -> secp256k1.Signing.ECDSASignature {
         try signature(for: SHA256.hash(data: data))
+    }
+    
+    /// Generates an ECDSA signature over the secp256k1 elliptic curve.
+    /// Condition: data is a 32-byte (256-bit) hash
+    ///
+    /// - Parameter data: The data to sign.
+    /// - Returns: The ECDSA Signature.
+    /// - Throws: If there is a failure producing the signature.
+    public func signature(hash: [UInt8]) throws -> secp256k1.Signing.ECDSASignature {
+        var signature = secp256k1_ecdsa_signature()
+
+        guard secp256k1_ecdsa_sign(secp256k1.Context.raw, &signature, hash, Array(signingKey.rawRepresentation), nil, nil).boolValue else {
+            throw secp256k1Error.underlyingCryptoError
+        }
+
+        return try secp256k1.Signing.ECDSASignature(signature.dataValue)
     }
 }
 
@@ -189,13 +199,7 @@ extension secp256k1.Signing.ECDSAValidator: DigestValidator, DataValidator {
     ///   - digest: The digest that was signed.
     /// - Returns: True if the signature is valid, false otherwise.
     public func isValidSignature<D: Digest>(_ signature: secp256k1.Signing.ECDSASignature, for digest: D) -> Bool {
-        var secp256k1Signature = secp256k1_ecdsa_signature()
-        var secp256k1PublicKey = secp256k1_pubkey()
-
-        signature.rawRepresentation.copyToUnsafeMutableBytes(of: &secp256k1Signature.data)
-
-        return secp256k1_ec_pubkey_parse(secp256k1.Context.raw, &secp256k1PublicKey, validatingKey.bytes, validatingKey.bytes.count).boolValue &&
-            secp256k1_ecdsa_verify(secp256k1.Context.raw, &secp256k1Signature, Array(digest), &secp256k1PublicKey).boolValue
+        isValidSignature(signature, hash: Array(digest))
     }
 
     /// Verifies an ECDSA signature over the secp256k1 elliptic curve.
@@ -207,5 +211,22 @@ extension secp256k1.Signing.ECDSAValidator: DigestValidator, DataValidator {
     /// - Returns: True if the signature is valid, false otherwise.
     public func isValidSignature<D: DataProtocol>(_ signature: secp256k1.Signing.ECDSASignature, for data: D) -> Bool {
         isValidSignature(signature, for: SHA256.hash(data: data))
+    }
+    
+    /// Verifies an ECDSA signature over the secp256k1 elliptic curve.
+    /// Condition: data is a 32-byte (256-bit) hash
+    ///
+    /// - Parameters:
+    ///   - signature: The signature to verify
+    ///   - data: The data that was signed.
+    /// - Returns: True if the signature is valid, false otherwise.
+    public func isValidSignature(_ signature: secp256k1.Signing.ECDSASignature, hash: [UInt8]) -> Bool {
+        var secp256k1Signature = secp256k1_ecdsa_signature()
+        var secp256k1PublicKey = secp256k1_pubkey()
+
+        signature.rawRepresentation.copyToUnsafeMutableBytes(of: &secp256k1Signature.data)
+        
+        return secp256k1_ec_pubkey_parse(secp256k1.Context.raw, &secp256k1PublicKey, validatingKey.bytes, validatingKey.bytes.count).boolValue &&
+            secp256k1_ecdsa_verify(secp256k1.Context.raw, &secp256k1Signature, hash, &secp256k1PublicKey).boolValue
     }
 }

--- a/Sources/implementation/SHA256.swift
+++ b/Sources/implementation/SHA256.swift
@@ -15,19 +15,19 @@ public enum SHA256 {
     /// Computes a digest of the data.
     /// - Parameter data: The data to be hashed
     /// - Returns: The computed digest
-    public static func hash<D: DataProtocol>(data: D) -> SHA256Digest {
+    public static func hash<D: DataProtocol>(data: D) -> SHA32BytesDigest {
         let stringData = Array(data)
         var output = [UInt8](repeating: 0, count: 32)
 
         secp256k1_swift_sha256(&output, stringData, stringData.count)
 
-        return convert(output)
+        return .init(output)
     }
 
     /// Computes a digest of the data.
     /// - Parameter data: The data to be hashed
     /// - Returns: The computed digest
-    public static func taggedHash<D: DataProtocol>(tag: [UInt8], data: D) throws -> SHA256Digest {
+    public static func taggedHash<D: DataProtocol>(tag: [UInt8], data: D) throws -> SHA32BytesDigest {
         let messageBytes = Array(data)
         var output = [UInt8](repeating: 0, count: 32)
 
@@ -35,15 +35,6 @@ public enum SHA256 {
             throw secp256k1Error.underlyingCryptoError
         }
 
-        return convert(output)
-    }
-
-    private static func convert(_ output: [UInt8]) -> SHA256Digest {
-        let first = output[0..<8].withUnsafeBytes { $0.load(as: UInt64.self) }
-        let second = output[8..<16].withUnsafeBytes { $0.load(as: UInt64.self) }
-        let third = output[16..<24].withUnsafeBytes { $0.load(as: UInt64.self) }
-        let forth = output[24..<32].withUnsafeBytes { $0.load(as: UInt64.self) }
-
-        return SHA256Digest(bytes: (first, second, third, forth))
+        return .init(output)
     }
 }

--- a/Sources/implementation/SHA256.swift
+++ b/Sources/implementation/SHA256.swift
@@ -15,7 +15,7 @@ public enum SHA256 {
     /// Computes a digest of the data.
     /// - Parameter data: The data to be hashed
     /// - Returns: The computed digest
-    public static func hash<D: DataProtocol>(data: D) -> SHA32BytesDigest {
+    public static func hash<D: DataProtocol>(data: D) -> SHA256Digest {
         let stringData = Array(data)
         var output = [UInt8](repeating: 0, count: 32)
 
@@ -27,7 +27,7 @@ public enum SHA256 {
     /// Computes a digest of the data.
     /// - Parameter data: The data to be hashed
     /// - Returns: The computed digest
-    public static func taggedHash<D: DataProtocol>(tag: [UInt8], data: D) throws -> SHA32BytesDigest {
+    public static func taggedHash<D: DataProtocol>(tag: [UInt8], data: D) throws -> SHA256Digest {
         let messageBytes = Array(data)
         var output = [UInt8](repeating: 0, count: 32)
 

--- a/Tests/secp256k1Tests/secp256k1Tests.swift
+++ b/Tests/secp256k1Tests/secp256k1Tests.swift
@@ -163,7 +163,7 @@ final class secp256k1Tests: XCTestCase {
         
         let digest = SHA256.hash(data: data)
         
-        let constructedDigest = SHA32BytesDigest(expectedHash)
+        let constructedDigest = Hash32BytesDigest(expectedHash)
         
         // Verify the generated hash digest matches the manual constructed hash digest
         XCTAssertEqual(String(bytes: Array(digest)), String(bytes: Array(constructedDigest)))

--- a/Tests/secp256k1Tests/secp256k1Tests.swift
+++ b/Tests/secp256k1Tests/secp256k1Tests.swift
@@ -157,6 +157,18 @@ final class secp256k1Tests: XCTestCase {
         XCTAssertEqual(expectedHashDigest, String(bytes: Array(digest)))
     }
 
+    func testSha32BytesDigest() {
+        let expectedHash = try! "f08a78cbbaee082b052ae0708f32fa1e50c5c421aa772ba5dbb406a2ea6be342".bytes
+        let data = "For this sample, this 63-byte string will be used as input data".data(using: .utf8)!
+        
+        let digest = SHA256.hash(data: data)
+        
+        let constructedDigest = SHA32BytesDigest(expectedHash)
+        
+        // Verify the generated hash digest matches the manual constructed hash digest
+        XCTAssertEqual(String(bytes: Array(digest)), String(bytes: Array(constructedDigest)))
+    }
+    
     func testSigning() {
         let expectedDerSignature = "MEQCIHS177uYACnX8HzD+hGbG5X/F4iHuRm2DvTylOCV4fmsAiBWbj0MDud/oVzRqL87JjZpCN+kLl8Egcc/GiOigWJg+A=="
         let expectedSignature = "rPnhleCU8vQOthm5h4gX/5UbmxH6w3zw1ykAmLvvtXT4YGKBoiMaP8eBBF8upN8IaTYmO7+o0Vyhf+cODD1uVg=="
@@ -420,6 +432,7 @@ final class secp256k1Tests: XCTestCase {
         ("testSchnorrBindings", testSchnorrBindings),
         ("testCompressedKeypairImplementationWithRaw", testCompressedKeypairImplementationWithRaw),
         ("testSha256", testSha256),
+        ("testSha32BytesDigest", testSha32BytesDigest),
         ("testSigning", testSigning),
         ("testSchnorrSigning", testSchnorrSigning),
         ("testVerifying", testVerifying),


### PR DESCRIPTION
Enables the usage of other hash algorithms that aren't supported by the library like SHA3 for example.