### PR TITLE
Make compact signature fields public

### DIFF
--- a/Sources/zkp/Recovery.swift
+++ b/Sources/zkp/Recovery.swift
@@ -66,8 +66,8 @@ public extension secp256k1 {
 public extension secp256k1.Recovery {
     /// Recovery Signature
     struct ECDSACompactSignature {
-        let signature: Data
-        let recoveryId: Int32
+        public let signature: Data
+        public let recoveryId: Int32
     }
 
     struct ECDSASignature: ContiguousBytes, RawSignature {


### PR DESCRIPTION
I needed to access these in a project. If there's a good reason for these fields to be internal, feel free to close this.