### PR TITLE
Adding checkmem from upstream

### DIFF
--- a/Sources/secp256k1_bindings/src/checkmem.h
+++ b/Sources/secp256k1_bindings/src/checkmem.h
@@ -1,0 +1,1 @@
+../../../Submodules/secp256k1/src/checkmem.h


### PR DESCRIPTION
🛠️ Fixes broken introduced in https://github.com/GigaBitcoin/secp256k1.swift/pull/283