### PR TITLE
Change partialSignature to use xonly internally

### DIFF
--- a/Sources/ZKP/MuSig.swift
+++ b/Sources/ZKP/MuSig.swift
@@ -363,7 +363,7 @@ public extension P256K.Schnorr.PrivateKey {
         pubnonce: P256K.Schnorr.Nonce,
         secureNonce: consuming P256K.Schnorr.SecureNonce,
         publicNonceAggregate: P256K.MuSig.Nonce,
-        publicKeyAggregate: P256K.MuSig.PublicKey
+        xonlyKeyAggregate: P256K.MuSig.XonlyKey
     ) throws -> P256K.Schnorr.PartialSignature {
         let context = P256K.Context.rawRepresentation
         var signature = secp256k1_musig_partial_sig()
@@ -379,7 +379,7 @@ public extension P256K.Schnorr.PrivateKey {
         }
 
         secureNonce.data.copyToUnsafeMutableBytes(of: &secnonce.data)
-        publicKeyAggregate.keyAggregationCache.copyToUnsafeMutableBytes(of: &cache.data)
+        xonlyKeyAggregate.cache.copyToUnsafeMutableBytes(of: &cache.data)
         publicNonceAggregate.aggregatedNonce.copyToUnsafeMutableBytes(of: &aggnonce.data)
 
         #if canImport(libsecp256k1_zkp)
@@ -406,7 +406,7 @@ public extension P256K.Schnorr.PrivateKey {
 
     /// Generates a partial signature for MuSig using SHA256 as the hash function.
     ///
-    /// This is a convenience method that hashes the input data using SHA256 before signing.
+    /// This is a convenience method that extracts the xonlyKeyAggregate from the public key aggregate.
     ///
     /// - Parameters:
     ///   - data: The data to sign.
@@ -416,19 +416,19 @@ public extension P256K.Schnorr.PrivateKey {
     ///   - publicKeyAggregate: The aggregate of all signers' public keys.
     /// - Returns: A partial MuSig signature.
     /// - Throws: An error if partial signature generation fails.
-    func partialSignature<D: DataProtocol>(
-        for data: D,
+    func partialSignature<D: Digest>(
+        for digest: D,
         pubnonce: P256K.Schnorr.Nonce,
         secureNonce: consuming P256K.Schnorr.SecureNonce,
         publicNonceAggregate: P256K.MuSig.Nonce,
         publicKeyAggregate: P256K.MuSig.PublicKey
     ) throws -> P256K.Schnorr.PartialSignature {
         try partialSignature(
-            for: SHA256.hash(data: data),
+            for: digest,
             pubnonce: pubnonce,
             secureNonce: secureNonce,
             publicNonceAggregate: publicNonceAggregate,
-            publicKeyAggregate: publicKeyAggregate
+            xonlyKeyAggregate: publicKeyAggregate.xonly
         )
     }
 }

--- a/Tests/ZKPTests/AsymmetricTests.swift
+++ b/Tests/ZKPTests/AsymmetricTests.swift
@@ -34,21 +34,21 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Verify compressed public key characteristics")
-    func testCompressedPublicKey() {
+    func compressedPublicKey() {
         let privateKey = try! P256K.Signing.PrivateKey()
         #expect(privateKey.publicKey.format == .compressed, "PublicKey format should be compressed")
         #expect(privateKey.publicKey.dataRepresentation.count == P256K.Format.compressed.length, "PublicKey length mismatch for compressed format")
     }
 
     @Test("Verify uncompressed public key characteristics")
-    func testUncompressedPublicKey() {
+    func uncompressedPublicKey() {
         let privateKey = try! P256K.Signing.PrivateKey(format: .uncompressed)
         #expect(privateKey.publicKey.format == .uncompressed, "PublicKey format should be uncompressed")
         #expect(privateKey.publicKey.dataRepresentation.count == P256K.Format.uncompressed.length, "PublicKey length mismatch for uncompressed format")
     }
 
     @Test("Verify uncompressed public key with specific bytes")
-    func testUncompressedPublicKeyWithKey() {
+    func uncompressedPublicKeyWithKey() {
         let privateBytes = try! "703d3b63e84421e59f9359f8b27c25365df9d85b6b1566e3168412fa599c12f4".bytes
         let privateKey = try! P256K.Signing.PrivateKey(dataRepresentation: privateBytes, format: .uncompressed)
         #expect(privateKey.publicKey.format == .uncompressed, "PublicKey format should be uncompressed")
@@ -62,7 +62,7 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Verify invalid private key bytes throw appropriate error")
-    func testInvalidPrivateKeyBytes() {
+    func invalidPrivateKeyBytes() {
         let expectedPrivateKey = "55f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"
         #expect(throws: (any Error).self) {
             _ = try expectedPrivateKey.bytes
@@ -70,7 +70,7 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Verify initialization with invalid private key length throws appropriate error")
-    func testInvalidPrivateKeyLength() {
+    func invalidPrivateKeyLength() {
         let expectedPrivateKey = "555f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"
         let privateKeyBytes = try! expectedPrivateKey.bytes
 
@@ -80,7 +80,7 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Test conversion of xonly public key to full public key")
-    func testXonlyToPublicKey() {
+    func xonlyToPublicKey() {
         let privateKey = try! P256K.Signing.PrivateKey()
         let publicKey = P256K.Signing.PublicKey(xonlyKey: privateKey.publicKey.xonly)
 
@@ -88,7 +88,7 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Public Key Combination Test")
-    func testPubkeyCombine() {
+    func pubkeyCombine() {
         let publicKeyBytes1 = try! "021b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014".bytes
         let publicKeyBytes2 = try! "0260303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752".bytes
 
@@ -103,7 +103,7 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Uncompressed Public Key Test")
-    func testKeyFormatConversion() {
+    func keyFormatConversion() {
         let pubkey = try! P256K.Signing.PublicKey(
             dataRepresentation: "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2".bytes,
             format: .compressed
@@ -113,7 +113,7 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Private Key PEM Test")
-    func testPrivateKeyPEM() {
+    func privateKeyPEM() {
         let privateKeyString = """
         -----BEGIN EC PRIVATE KEY-----
         MHQCAQEEIBXwHPDpec6b07GeLbnwetT0dvWzp0nV3MR+4pPKXIc7oAcGBSuBBAAK
@@ -129,7 +129,7 @@ struct AsymmetricTestSuite {
     }
 
     @Test("Public Key PEM Test")
-    func testPublicKeyPEM() {
+    func publicKeyPEM() {
         let publicKeyString = """
         -----BEGIN PUBLIC KEY-----
         MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEt2uDn+2GqqYs/fmkBr5+rCQ3oiFSIJMA
@@ -146,7 +146,7 @@ struct AsymmetricTestSuite {
 
     @Test("Test UInt256")
     @available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, macCatalyst 16.4, visionOS 1.0, *)
-    func testUInt256() {
+    func uInt256() {
         let expectedPrivateKey: UInt256 = 0x7DA1_2CC3_9BB4_189A_C72D_34FC_2225_DF5C_F36A_AACD_CAC7_E5A4_3963_299B_C8D8_88ED
         let expectedPrivateKey2: UInt256 = 0x1BB5_FC86_3773_7549_414D_7F1B_82A5_C12D_234B_56DB_AC17_5E14_0F63_046A_EBA8_DF87
         let expectedPublicKey = "023521df7b94248ffdf0d37f738a4792cc3932b6b1b89ef71cddde8251383b26e7"

--- a/Tests/ZKPTests/ECDHTests.swift
+++ b/Tests/ZKPTests/ECDHTests.swift
@@ -19,7 +19,7 @@ import Testing
 
 struct ECDHTestSuite {
     @Test("Test Key Agreement")
-    func testKeyAgreement() {
+    func keyAgreement() {
         let privateString1 = "7da12cc39bb4189ac72d34fc2225df5cf36aaacdcac7e5a43963299bc8d888ed"
         let privateString2 = "5f6d5afecc677d66fb3d41eee7a8ad8195659ceff588edaf416a9a17daf38fdd"
 
@@ -36,7 +36,7 @@ struct ECDHTestSuite {
     }
 
     @Test("Test Key Agreement Public Key Tweak Addition")
-    func testKeyAgreementPublicKeyTweakAdd() {
+    func keyAgreementPublicKeyTweakAdd() {
         let privateSign1 = try! P256K.Signing.PrivateKey()
         let privateSign2 = try! P256K.Signing.PrivateKey()
 

--- a/Tests/ZKPTests/ECDSATests.swift
+++ b/Tests/ZKPTests/ECDSATests.swift
@@ -65,21 +65,21 @@ struct ECDSATestSuite {
     }
 
     @Test("Verify invalid raw signature initialization throws correct error")
-    func testInvalidRawSignature() {
+    func invalidRawSignature() {
         #expect(throws: secp256k1Error.incorrectParameterSize) {
             _ = try P256K.Signing.ECDSASignature(dataRepresentation: Data())
         }
     }
 
     @Test("Verify invalid DER signature initialization throws correct error")
-    func testInvalidDerSignature() {
+    func invalidDerSignature() {
         #expect(throws: secp256k1Error.underlyingCryptoError) {
             _ = try P256K.Signing.ECDSASignature(derRepresentation: Data())
         }
     }
 
     @Test("Signing with PEM representation")
-    func testSigningPEM() {
+    func signingPEM() {
         let privateKeyString = """
         -----BEGIN EC PRIVATE KEY-----
         MHQCAQEEIBXwHPDpec6b07GeLbnwetT0dvWzp0nV3MR+4pPKXIc7oAcGBSuBBAAK
@@ -99,7 +99,7 @@ struct ECDSATestSuite {
     }
 
     @Test("Verifying with PEM representation")
-    func testVerifyingPEM() {
+    func verifyingPEM() {
         let publicKeyString = """
         -----BEGIN PUBLIC KEY-----
         MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEt2uDn+2GqqYs/fmkBr5+rCQ3oiFSIJMA

--- a/Tests/ZKPTests/MusigTests.swift
+++ b/Tests/ZKPTests/MusigTests.swift
@@ -19,7 +19,7 @@ import Testing
 
 struct MuSigTestSuite {
     @Test("MuSig Signing and Verification")
-    func testMusig() {
+    func musig() {
         // Test MuSig aggregate
         let privateKeys = [
             try! P256K.Schnorr.PrivateKey(),
@@ -65,7 +65,7 @@ struct MuSigTestSuite {
             pubnonce: firstNonce.pubnonce,
             secureNonce: firstNonce.secnonce,
             publicNonceAggregate: aggregateNonce,
-            publicKeyAggregate: aggregate
+            xonlyKeyAggregate: aggregate.xonly
         )
 
         let secondPartialSignature = try! privateKeys[1].partialSignature(

--- a/Tests/ZKPTests/SchnorrTests.swift
+++ b/Tests/ZKPTests/SchnorrTests.swift
@@ -74,7 +74,7 @@ struct SchnorrTestSuite {
     }
 
     @Test("Test Schnorr Negating")
-    func testSchnorrNegating() {
+    func schnorrNegating() {
         let privateBytes = try! "56baa476b36a5b1548279f5bf57b82db39e594aee7912cde30977b8e80e6edca".bytes
         let negatedBytes = try! "a9455b894c95a4eab7d860a40a847d2380c94837c7b7735d8f3ae2fe4f4f5377".bytes
 

--- a/Tests/ZKPTests/TaprootTests.swift
+++ b/Tests/ZKPTests/TaprootTests.swift
@@ -19,7 +19,7 @@ import Testing
 
 struct TaprootTestSuite {
     @Test("Test Taproot Derivation")
-    func testTaprootDerivation() {
+    func taprootDerivation() {
         let privateKeyBytes = try! "41F41D69260DF4CF277826A9B65A3717E4EEDDBEEDF637F212CA096576479361".bytes
         let privateKey = try! P256K.Schnorr.PrivateKey(dataRepresentation: privateKeyBytes)
         let internalKeyBytes = try! "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115".bytes
@@ -39,7 +39,7 @@ struct TaprootTestSuite {
     }
 
     @Test("Test Tapscript execution and hash verification")
-    func testTapscript() {
+    func tapscript() {
         let OP_CHECKSEQUENCEVERIFY = Data([0xB2])
         let OP_DROP = Data([0x75])
         let OP_CHECKSIG = Data([0xAC])

--- a/Tests/ZKPTests/TweakTests.swift
+++ b/Tests/ZKPTests/TweakTests.swift
@@ -18,7 +18,7 @@ import Testing
 
 struct TweakTestSuite {
     @Test("Verify private key tweak addition produces expected result")
-    func testPrivateKeyTweakAdd() {
+    func privateKeyTweakAdd() {
         let expectedPrivateKey = "7da12cc39bb4189ac72d34fc2225df5cf36aaacdcac7e5a43963299bc8d888ed"
         let expectedPublicKey = "023521df7b94248ffdf0d37f738a4792cc3932b6b1b89ef71cddde8251383b26e7"
         let expectedTweakedPrivateKey = "5f0da318c6e02f653a789950e55756ade9f194e1ec228d7f368de1bd821322b6"

--- a/Tests/ZKPTests/UtilityTests.swift
+++ b/Tests/ZKPTests/UtilityTests.swift
@@ -19,7 +19,7 @@ import Testing
 
 struct UtilityTestSuite {
     @Test("Verify keypair equality checks work correctly")
-    func testKeypairSafeCompare() {
+    func keypairSafeCompare() {
         let expectedPrivateKey = "7da12cc39bb4189ac72d34fc2225df5cf36aaacdcac7e5a43963299bc8d888ed"
         var privateKeyBytes = try! expectedPrivateKey.bytes
         let privateKey0 = try! P256K.Signing.PrivateKey(dataRepresentation: privateKeyBytes)
@@ -36,7 +36,7 @@ struct UtilityTestSuite {
     }
 
     @Test("Verify memory zeroization works correctly")
-    func testZeroization() {
+    func zeroization() {
         var array: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
         memset_s(&array, array.capacity, 0, array.capacity)


### PR DESCRIPTION
@RubenWaterman I’m opening this PR based on the changes you’ve sent me. I’ve simplified your fix, and it should address the issue. https://github.com/21-DOT-DEV/swift-secp256k1/issues/697