### PR TITLE
docs: Add comprehensive documentation guides and explanations

### DIFF
--- a/Sources/P256K/P256K.docc/KeyFormats.md
+++ b/Sources/P256K/P256K.docc/KeyFormats.md
@@ -1,0 +1,79 @@
+# Key Formats
+
+@Metadata {
+    @TitleHeading("Explanation")
+}
+
+Understand why secp256k1 has multiple key representations and when to use each one.
+
+## Elliptic Curve Points
+
+A secp256k1 public key is a point `(x, y)` on the elliptic curve. Both coordinates are 256-bit (32-byte) integers. Since the curve equation `y^2 = x^3 + 7` has exactly two solutions for each `x` value (one even, one odd), you only need the `x` coordinate plus a single bit to identify the point uniquely.
+
+## Compressed Keys (33 bytes)
+
+The **compressed** format stores the x-coordinate with a one-byte prefix indicating the parity of y:
+
+- `0x02` -- y is even
+- `0x03` -- y is odd
+
+This is the default format in P256K and the standard for Bitcoin since 2012:
+
+```swift
+let key = try P256K.Signing.PrivateKey()  // compressed by default
+key.publicKey.dataRepresentation.count    // 33
+key.publicKey.format                      // .compressed
+```
+
+## Uncompressed Keys (65 bytes)
+
+The **uncompressed** format stores both coordinates with a `0x04` prefix:
+
+```swift
+let key = try P256K.Signing.PrivateKey(format: .uncompressed)
+key.publicKey.dataRepresentation.count    // 65
+key.publicKey.format                      // .uncompressed
+```
+
+Uncompressed keys are rarely used in modern Bitcoin but appear in legacy transactions and some non-Bitcoin protocols. P256K supports them for interoperability.
+
+## X-Only Keys (32 bytes)
+
+BIP-340 introduced **x-only** public keys for Schnorr signatures. These are simply the 32-byte x-coordinate with no prefix byte. The y-coordinate is implicitly defined as the **even** value.
+
+```swift
+let schnorrKey = try P256K.Schnorr.PrivateKey()
+schnorrKey.xonly.bytes.count  // 32
+```
+
+X-only keys save 1 byte per public key and simplify the Schnorr verification equation. They are used in:
+- BIP-340 Schnorr signatures
+- BIP-341 Taproot output keys
+- BIP-327 MuSig2 aggregate keys
+
+## Key Parity
+
+The `parity` property on x-only key types indicates whether the full point's y-coordinate is odd (`true`) or even (`false`).
+
+For ``P256K/Signing/XonlyKey``, parity is derived from the original full public key and can be either value. For ``P256K/Schnorr/XonlyKey``, parity is implicitly even and always returns `false`.
+
+Parity matters when:
+- **Taproot tweak verification** -- You need to know whether the internal key was negated during output key derivation.
+- **MuSig2 key aggregation** -- The aggregate key's parity affects how partial signatures are combined.
+
+## The Format Enum
+
+``P256K/Format`` controls key serialization:
+
+| Case | Value | Length | C Flag |
+|------|-------|--------|--------|
+| `.compressed` | `0x0202` | 33 bytes | `SECP256K1_EC_COMPRESSED` |
+| `.uncompressed` | `0x0604` | 65 bytes | `SECP256K1_EC_UNCOMPRESSED` |
+
+The `rawValue` maps directly to the flag passed to the underlying C library's serialization functions.
+
+## Choosing a Format
+
+- **Default to compressed** for all new applications. It is the standard for Bitcoin, smaller, and fully supported.
+- **Use x-only** when working with Schnorr signatures, Taproot, or MuSig2.
+- **Use uncompressed** only when required by a legacy protocol or for compatibility with systems that expect the `0x04` prefix.

--- a/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
+++ b/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
@@ -1,0 +1,99 @@
+# MuSig2 Multi-Signatures
+
+@Metadata {
+    @TitleHeading("How-to Guide")
+}
+
+Create a single Schnorr signature from multiple independent signers using the BIP-327 MuSig2 protocol.
+
+## Overview
+
+MuSig2 allows multiple parties to produce a single compact Schnorr signature that verifies against an aggregated public key. No observer can distinguish a MuSig2 signature from a regular Schnorr signature. This guide walks through the complete signing protocol.
+
+## Aggregating Public Keys
+
+Each signer generates a Schnorr key pair. The public keys are then aggregated into a single ``P256K/MuSig/PublicKey``:
+
+```swift
+import P256K
+
+let alice = try P256K.Schnorr.PrivateKey()
+let bob = try P256K.Schnorr.PrivateKey()
+let carol = try P256K.Schnorr.PrivateKey()
+
+let aggregate = try P256K.MuSig.aggregate([
+    alice.publicKey, bob.publicKey, carol.publicKey
+])
+```
+
+Key aggregation is order-independent -- the same aggregate is produced regardless of the order the public keys are provided.
+
+## Generating Nonces
+
+Each signer independently generates a nonce pair. The `generate` function returns a ``P256K/Schnorr/SecureNonce`` (the secret nonce) and a public nonce:
+
+```swift
+let message = "Hello, MuSig!".data(using: .utf8)!
+let messageHash = SHA256.hash(data: message)
+
+let aliceNonce = try P256K.MuSig.Nonce.generate(
+    secretKey: alice,
+    publicKey: alice.publicKey,
+    msg32: Array(messageHash)
+)
+```
+
+> Warning: A `SecureNonce` is `~Copyable` by design. Using the same secret nonce in two different signing sessions **leaks the signing key**. The type system prevents accidental reuse.
+
+## Aggregating Nonces
+
+Each signer shares their public nonce. Once all public nonces are collected, aggregate them:
+
+```swift
+let aggregateNonce = try P256K.MuSig.Nonce(aggregating: [
+    aliceNonce.pubnonce, bobNonce.pubnonce, carolNonce.pubnonce
+])
+```
+
+## Creating Partial Signatures
+
+Each signer creates a partial signature using their private key, their secret nonce, and the aggregated nonce:
+
+```swift
+let alicePartial = try alice.partialSignature(
+    for: messageHash,
+    pubnonce: aliceNonce.pubnonce,
+    secureNonce: aliceNonce.secnonce,
+    publicNonceAggregate: aggregateNonce,
+    publicKeyAggregate: aggregate
+)
+```
+
+## Aggregating Signatures
+
+Once all partial signatures are collected, aggregate them into the final Schnorr signature:
+
+```swift
+let finalSignature = try P256K.MuSig.aggregateSignatures([
+    alicePartial, bobPartial, carolPartial
+])
+```
+
+## Verification
+
+The final signature verifies against the aggregated x-only public key, just like any BIP-340 Schnorr signature:
+
+```swift
+let isValid = aggregate.xonly.isValidSignature(finalSignature, for: messageHash)
+```
+
+You can also verify individual partial signatures before aggregation:
+
+```swift
+let isPartialValid = aggregate.isValidSignature(
+    alicePartial,
+    publicKey: alice.publicKey,
+    nonce: aliceNonce.pubnonce,
+    for: messageHash
+)
+```

--- a/Sources/P256K/P256K.docc/P256K.md
+++ b/Sources/P256K/P256K.docc/P256K.md
@@ -66,3 +66,16 @@ All operations require a secp256k1 context. The library provides a shared ``P256
 - ``UInt256``
 - ``secp256k1Error``
 - ``CryptoKitError``
+
+### Guides
+
+- <doc:GettingStarted>
+- <doc:MuSig2MultiSignatures>
+- <doc:TweakingKeys>
+- <doc:RecoveringPublicKeys>
+- <doc:SerializingKeys>
+
+### Concepts
+
+- <doc:SecurityConsiderations>
+- <doc:KeyFormats>

--- a/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
+++ b/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
@@ -1,0 +1,71 @@
+# Recovering Public Keys
+
+@Metadata {
+    @TitleHeading("How-to Guide")
+}
+
+Recover an ECDSA public key from a recoverable signature and its recovery ID.
+
+## Creating a Recoverable Signature
+
+Use ``P256K/Recovery/PrivateKey`` to produce a recoverable ECDSA signature. Unlike standard ECDSA signatures, recoverable signatures include a recovery ID that identifies which of up to four candidate public keys produced the signature:
+
+```swift
+let privateKey = try P256K.Recovery.PrivateKey(
+    dataRepresentation: keyBytes
+)
+let message = "We're all Satoshi.".data(using: .utf8)!
+
+let recoverySignature = privateKey.signature(for: message)
+```
+
+## Recovering the Public Key
+
+Recover the signer's public key from the message and recoverable signature:
+
+```swift
+let recoveredKey = P256K.Recovery.PublicKey(message, signature: recoverySignature)
+
+// The recovered key matches the original
+recoveredKey.dataRepresentation == privateKey.publicKey.dataRepresentation
+```
+
+You can also recover from a hash digest:
+
+```swift
+let digest = SHA256.hash(data: message)
+let recoveredKey = P256K.Recovery.PublicKey(digest, signature: recoverySignature)
+```
+
+## Compact Representation and Recovery ID
+
+A recoverable signature can be serialized as a compact representation (64 bytes) plus a separate recovery ID (0-3):
+
+```swift
+let compact = recoverySignature.compactRepresentation
+// compact.signature -- 64-byte compact ECDSA signature
+// compact.recoveryId -- Int32 (0, 1, 2, or 3)
+```
+
+Reconstruct from the compact form:
+
+```swift
+let restored = try P256K.Recovery.ECDSASignature(
+    compactRepresentation: compactBytes,
+    recoveryId: recoveryId
+)
+```
+
+## Converting to Standard ECDSA
+
+Use the ``P256K/Recovery/ECDSASignature/normalize`` property to convert a recoverable signature to a standard ECDSA signature:
+
+```swift
+let standardSignature = recoverySignature.normalize
+
+// Access standard formats
+standardSignature.dataRepresentation   // 64-byte compact
+standardSignature.derRepresentation    // DER-encoded
+```
+
+> Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's BIP-62 rule 6), call ``P256K/Signing/ECDSASignature/normalize`` on the result.

--- a/Sources/P256K/P256K.docc/SecurityConsiderations.md
+++ b/Sources/P256K/P256K.docc/SecurityConsiderations.md
@@ -1,0 +1,68 @@
+# Security Considerations
+
+@Metadata {
+    @TitleHeading("Explanation")
+}
+
+Understand the security properties of P256K and how to avoid common cryptographic pitfalls.
+
+## Context Randomization
+
+Every cryptographic operation in P256K depends on a secp256k1 context managed by ``P256K/Context``. The shared context is created and **randomized** once at process startup using OS-provided entropy.
+
+Randomization seeds a blinding factor that protects **ECDSA signing**, **Schnorr signing**, and **public key generation** against timing and power analysis attacks. The blinding factor is applied to the base point multiplication, making the internal computation pattern independent of the secret key.
+
+> Note: ECDH key agreement uses a different kind of elliptic curve point multiplication and does **not** currently benefit from context randomization.
+
+## Nonce Reuse
+
+The most dangerous mistake in elliptic curve cryptography is reusing a nonce (random value) across two different signing operations with the same private key. If the same nonce `k` is used to sign two different messages, an attacker can compute the private key from the two signatures using simple algebra.
+
+### MuSig2 SecureNonce
+
+P256K uses Swift's `~Copyable` (non-copyable) type for ``P256K/Schnorr/SecureNonce`` to prevent accidental nonce reuse at the type-system level. Once a `SecureNonce` is consumed by a signing operation, it cannot be used again:
+
+```swift
+let nonce = try P256K.MuSig.Nonce.generate(
+    secretKey: privateKey,
+    publicKey: privateKey.publicKey,
+    msg32: messageBytes
+)
+
+// The secnonce is consumed here -- it cannot be reused
+let partial = try privateKey.partialSignature(
+    for: digest,
+    pubnonce: nonce.pubnonce,
+    secureNonce: nonce.secnonce,  // consumed, cannot use again
+    publicNonceAggregate: aggregateNonce,
+    publicKeyAggregate: aggregate
+)
+```
+
+### ECDSA and Schnorr Nonces
+
+For standard (non-MuSig) ECDSA and Schnorr signing, P256K uses deterministic nonce generation (RFC 6979 for ECDSA, BIP-340 for Schnorr) by default, which eliminates the risk of random nonce reuse entirely.
+
+## Constant-Time Comparison
+
+When comparing secret values (shared secrets, keys, signatures), use constant-time comparison to avoid timing side-channels. P256K's ``SharedSecret`` type uses constant-time equality internally:
+
+```swift
+let secret1 = alice.sharedSecretFromKeyAgreement(with: bobPublicKey)
+let secret2 = bob.sharedSecretFromKeyAgreement(with: alicePublicKey)
+
+// This comparison is constant-time
+secret1 == secret2
+```
+
+Never compare secret bytes using standard `==` on `Data` or `[UInt8]`, as this may short-circuit on the first differing byte, leaking information about which bytes match.
+
+## Secret Key Zeroization
+
+P256K uses `SecureBytes` internally for private key storage. When a `SecureBytes` value is deallocated, its memory is overwritten with zeros using `memset_s` (or an equivalent that the compiler cannot optimize away). This prevents secret key material from lingering in memory after the key object is destroyed.
+
+## ECDSA Signature Malleability
+
+An ECDSA signature `(r, s)` has a counterpart `(r, n - s)` that is also valid for the same message and public key. This **malleability** can cause problems in systems that use the signature as a unique transaction identifier (e.g., Bitcoin before SegWit).
+
+P256K enforces **lower-S normalization** (BIP-62 rule 6): `secp256k1_ecdsa_verify` only accepts signatures where `s` is in the lower half of the curve order. The ``P256K/Signing/PrivateKey/signature(for:)-1hf2o`` method always produces normalized signatures, and ``P256K/Recovery/ECDSASignature/normalize`` converts recoverable signatures to the canonical form.

--- a/Sources/P256K/P256K.docc/SerializingKeys.md
+++ b/Sources/P256K/P256K.docc/SerializingKeys.md
@@ -1,0 +1,115 @@
+# Serializing Keys
+
+@Metadata {
+    @TitleHeading("How-to Guide")
+}
+
+Import and export keys in raw bytes, PEM, DER, and other standard formats.
+
+## Raw Bytes
+
+The most common serialization. Use `dataRepresentation` to export and `init(dataRepresentation:format:)` to import:
+
+```swift
+// Export (33 bytes compressed, 65 bytes uncompressed)
+let keyData = publicKey.dataRepresentation
+
+// Import with explicit format
+let restored = try P256K.Signing.PublicKey(
+    dataRepresentation: keyData,
+    format: .compressed
+)
+```
+
+Private keys are always 32 bytes:
+
+```swift
+let privKeyData = privateKey.dataRepresentation  // 32 bytes
+let restored = try P256K.Signing.PrivateKey(dataRepresentation: privKeyData)
+```
+
+## PEM Encoding
+
+Import keys from PEM-encoded strings. Both SEC1 (`EC PRIVATE KEY`) and PKCS#8 (`PRIVATE KEY`) formats are supported:
+
+```swift
+let pemString = """
+-----BEGIN EC PRIVATE KEY-----
+MHQCAQEEIBXwHPDpec6b07GeLbnwetT0dvWzp0nV3MR+4pPKXIc7oAcGBSuBBAAK
+oUQDQgAEt2uDn+2GqqYs/fmkBr5+rCQ3oiFSIJMAcjHIrTDS6HEELgguOatmFBOp
+2wU4P2TAl/0Ihiq+nMkrAIV69m2W8g==
+-----END EC PRIVATE KEY-----
+"""
+let privateKey = try P256K.Signing.PrivateKey(pemRepresentation: pemString)
+```
+
+Public keys use the `PUBLIC KEY` PEM type:
+
+```swift
+let publicKey = try P256K.Signing.PublicKey(pemRepresentation: publicKeyPEM)
+```
+
+## DER Encoding
+
+Import from DER-encoded binary data:
+
+```swift
+let privateKey = try P256K.Signing.PrivateKey(derRepresentation: derBytes)
+let publicKey = try P256K.Signing.PublicKey(derRepresentation: derBytes)
+```
+
+ECDSA signatures also support DER:
+
+```swift
+let signature = try P256K.Signing.ECDSASignature(derRepresentation: derData)
+let derBytes = signature.derRepresentation
+```
+
+## Compressed vs Uncompressed
+
+Specify the format when creating keys:
+
+```swift
+// Compressed (default): 33-byte public key with 0x02 or 0x03 prefix
+let compressed = try P256K.Signing.PrivateKey(format: .compressed)
+compressed.publicKey.dataRepresentation.count  // 33
+
+// Uncompressed: 65-byte public key with 0x04 prefix
+let uncompressed = try P256K.Signing.PrivateKey(format: .uncompressed)
+uncompressed.publicKey.dataRepresentation.count  // 65
+```
+
+Convert a compressed public key to its uncompressed form:
+
+```swift
+let fullBytes = compressedPublicKey.uncompressedRepresentation  // 65 bytes
+```
+
+## X-Only Keys
+
+Schnorr signatures (BIP-340) use 32-byte x-only public keys with implicit even parity:
+
+```swift
+let schnorrKey = try P256K.Schnorr.PrivateKey()
+let xonlyBytes = schnorrKey.xonly.bytes  // [UInt8], 32 bytes
+```
+
+Convert between full public keys and x-only:
+
+```swift
+// Full key to x-only
+let xonly = ecdsaPublicKey.xonly
+
+// X-only back to full key (original parity preserved)
+let fullKey = P256K.Signing.PublicKey(xonlyKey: xonly)
+```
+
+## Format Comparison
+
+| Format | Size | Prefix | Use Case |
+|--------|------|--------|----------|
+| Compressed | 33 bytes | `0x02` / `0x03` | Default, blockchain storage |
+| Uncompressed | 65 bytes | `0x04` | Legacy compatibility |
+| X-only | 32 bytes | None | BIP-340 Schnorr, Taproot |
+| DER (private) | ~118 bytes | ASN.1 | Interoperability |
+| PEM (private) | ~227 bytes | Base64 + header | Human-readable storage |

--- a/Sources/P256K/P256K.docc/TweakingKeys.md
+++ b/Sources/P256K/P256K.docc/TweakingKeys.md
@@ -1,0 +1,93 @@
+# Tweaking Keys
+
+@Metadata {
+    @TitleHeading("How-to Guide")
+}
+
+Derive child keys using additive and multiplicative tweaks for BIP-32 key derivation and BIP-341 Taproot.
+
+## ECDSA Key Tweaking
+
+Tweak an ECDSA private key by adding a scalar, producing a new key pair. This is the basis of BIP-32 hierarchical deterministic key derivation:
+
+```swift
+let privateKey = try P256K.Signing.PrivateKey(dataRepresentation: keyBytes)
+let tweak = SHA256.hash(data: someData)
+
+// Additive tweak: newKey = privateKey + tweak (mod n)
+let tweakedPrivateKey = try privateKey.add(Array(tweak))
+
+// Multiplicative tweak: newKey = privateKey * tweak (mod n)
+let tweakedByMul = try privateKey.multiply(Array(tweak))
+```
+
+Public keys can be tweaked directly without the private key:
+
+```swift
+// Additive: newPubKey = pubKey + tweak * G
+let tweakedPublicKey = try publicKey.add(Array(tweak))
+
+// Multiplicative: newPubKey = tweak * pubKey
+let tweakedByMul = try publicKey.multiply(Array(tweak))
+```
+
+## Schnorr Key Tweaking
+
+Schnorr keys use x-only (32-byte) public keys with implicit even parity. Tweaking a Schnorr key handles the parity adjustment automatically:
+
+```swift
+let schnorrKey = try P256K.Schnorr.PrivateKey(dataRepresentation: keyBytes)
+let tweak = SHA256.hash(data: someData)
+
+let tweakedKey = try schnorrKey.add(Array(tweak))
+```
+
+X-only public keys can also be tweaked directly:
+
+```swift
+let tweakedXonly = try schnorrKey.xonly.add(Array(tweak))
+```
+
+## Taproot Output Key Construction
+
+BIP-341 Taproot derives an output key from an internal key using a tagged hash tweak. For a key-path-only output (no script tree):
+
+```swift
+let internalKey = try P256K.Schnorr.PrivateKey(
+    dataRepresentation: keyBytes
+).xonly
+
+// Compute the taptweak: H_TapTweak(internalKey)
+let tweakHash = SHA256.taggedHash(
+    tag: "TapTweak".data(using: .utf8)!,
+    data: Data(internalKey.bytes)
+)
+
+// Derive the output key: internalKey + tweakHash
+let outputKey = try internalKey.add(Array(tweakHash))
+```
+
+For outputs with a script tree, include the Merkle root in the tweak:
+
+```swift
+// H_TapTweak(internalKey || merkleRoot)
+let tweakHash = SHA256.taggedHash(
+    tag: "TapTweak".data(using: .utf8)!,
+    data: Data(internalKey.bytes) + merkleRoot
+)
+let outputKey = try internalKey.add(Array(tweakHash))
+```
+
+## MuSig Aggregate Key Tweaking
+
+Aggregated MuSig2 keys can be tweaked for BIP-32 derivation or Taproot:
+
+```swift
+let aggregate = try P256K.MuSig.aggregate(publicKeys)
+
+// BIP-32 style: tweak the full public key
+let derivedKey = try aggregate.add(Array(tweak))
+
+// Taproot: tweak the x-only aggregate key
+let taprootOutput = try aggregate.xonly.add(Array(tweakHash))
+```

--- a/Sources/Shared/MuSig/MuSig+Aggregate.swift
+++ b/Sources/Shared/MuSig/MuSig+Aggregate.swift
@@ -158,11 +158,11 @@ public import Foundation
 
             /// Creates a ``PartialSignature`` from raw partial signature bytes and session data.
             ///
-            /// - Parameter dataRepresentation: Exactly 64 bytes of partial signature data from `secp256k1_musig_partial_sig_serialize`.
+            /// - Parameter dataRepresentation: The serialized partial signature data (36 bytes from `secp256k1_musig_partial_sig_serialize`).
             /// - Parameter session: The 133-byte `secp256k1_musig_session` state.
-            /// - Throws: ``secp256k1Error/incorrectParameterSize`` if `dataRepresentation` is not 64 bytes.
+            /// - Throws: ``secp256k1Error/incorrectParameterSize`` if the byte count does not match the expected partial signature length.
             public init<D: DataProtocol>(dataRepresentation: D, session: D) throws {
-                guard dataRepresentation.count == P256K.ByteLength.signature else {
+                guard dataRepresentation.count == P256K.ByteLength.partialSignature else {
                     throw secp256k1Error.incorrectParameterSize
                 }
 

--- a/Sources/Shared/Schnorr/Schnorr+XonlyKey.swift
+++ b/Sources/Shared/Schnorr/Schnorr+XonlyKey.swift
@@ -30,7 +30,7 @@ public import Foundation
                 baseKey.bytes
             }
 
-            /// Schnorr x-only public key are implicit of the point being even, therefore this will always return `false`.`
+            /// Schnorr x-only public key parity is implicitly even, therefore this always returns `false`.
             public var parity: Bool {
                 baseKey.keyParity.boolValue
             }

--- a/Sources/ZKP/ZKP.docc/ZKP.md
+++ b/Sources/ZKP/ZKP.docc/ZKP.md
@@ -1,0 +1,15 @@
+# ``ZKP``
+
+@Metadata {
+    @TitleHeading("Framework")
+}
+
+ZKP provides zero-knowledge proof primitives for the secp256k1 curve, built on the `libsecp256k1-zkp` library.
+
+## Overview
+
+The ZKP module wraps `libsecp256k1-zkp` with a Swift API for range proofs, surjection proofs, adaptor signatures, and other advanced cryptographic protocols used in confidential transactions and privacy-preserving systems.
+
+ZKP shares the same core cryptographic types as ``P256K`` (ECDSA, Schnorr, MuSig2, ECDH, key recovery) and extends them with additional zero-knowledge proof capabilities from the Elements/Liquid sidechain project.
+
+> Note: This module is under active development. Public API will be added in future releases.


### PR DESCRIPTION
Add six new documentation articles covering key concepts and how-to guides:
- KeyFormats.md: Explains compressed, uncompressed, and x-only key representations
- MuSig2MultiSignatures.md: Step-by-step guide for BIP-327 multi-signature protocol
- RecoveringPublicKeys.md: Guide for ECDSA public key recovery from signatures
- SecurityConsiderations.md: Covers context randomization, nonce reuse, and constant-time operations