### PR TITLE
docs: DocC refactor + release automation

### DIFF
--- a/.github/workflows/apple-builds.yml
+++ b/.github/workflows/apple-builds.yml
@@ -62,3 +62,15 @@ jobs:
             build \
             -scheme swift-secp256k1-Package \
             -destination generic/platform=visionOS
+
+  docc:
+    name: DocC Validation
+    runs-on: macos-26
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.4.app/Contents/Developer
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Validate P256K DocC
+        run: swift package generate-documentation --target P256K --analyze --warnings-as-errors
+      - name: Validate ZKP DocC
+        run: swift package generate-documentation --target ZKP --analyze --warnings-as-errors

--- a/.github/workflows/docc-release.yml
+++ b/.github/workflows/docc-release.yml
@@ -1,0 +1,174 @@
+name: DocC Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing release tag to upload the DocC archives to (e.g. 0.18.0 or 0.18.0-prerelease-0). The release must already exist.'
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: docc-release-${{ github.event.inputs.release_tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  docc:
+    name: Build DocC Archives
+    runs-on: macos-26
+    timeout-minutes: 30
+    permissions:
+      contents: write  # for gh release upload
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || github.ref_name }}
+      DEVELOPER_DIR: "/Applications/Xcode_26.4.app/Contents/Developer"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.release_tag || github.ref }}
+          fetch-depth: 0  # ensure tags are fetched so we can delete them below
+
+      - name: Enable development dependencies
+        # Delete ALL tags at HEAD so Context.gitInformation?.currentTag is nil,
+        # which flips the `developmentDependencies` guard in Package.swift and
+        # includes swift-docc-plugin. Single-tag deletion fails when a commit
+        # has sibling tags (e.g., 0.18.0 + 0.18.0-prerelease-0), causing
+        # "Unknown subcommand or plugin name 'generate-documentation'".
+        run: git tag --points-at HEAD | xargs -r -n 1 git tag -d
+
+      - name: Echo toolchain versions
+        run: |
+          {
+            echo "### Toolchain"
+            echo ""
+            echo '```'
+            swift --version
+            xcodebuild -version
+            xcrun docc --version 2>/dev/null || echo "docc --version: unsupported by this docc build"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build package
+        run: swift build
+
+      - name: Build P256K DocC Archive
+        env:
+          SOURCE_SERVICE_BASE_URL: "https://github.com/${{ github.repository }}/blob/${{ github.event.inputs.release_tag || github.ref_name }}"
+        run: |
+          mkdir -p docs
+          swift package \
+            --allow-writing-to-directory ./docs \
+            generate-documentation \
+            --target P256K \
+            --analyze \
+            --warnings-as-errors \
+            --enable-experimental-markdown-output \
+            --transform-for-static-hosting \
+            --experimental-transform-for-static-hosting-with-content \
+            --source-service github \
+            --source-service-base-url "$SOURCE_SERVICE_BASE_URL" \
+            --checkout-path "$GITHUB_WORKSPACE" \
+            --output-path ./docs/P256K.doccarchive
+
+      - name: Sanity-check P256K archive
+        run: |
+          test -d ./docs/P256K.doccarchive
+          test -f ./docs/P256K.doccarchive/metadata.json
+
+          BUNDLE_ID=$(jq -r '.bundleID // empty' ./docs/P256K.doccarchive/metadata.json)
+          echo "P256K bundle ID: ${BUNDLE_ID}"
+          [ -n "$BUNDLE_ID" ] || { echo "::error::P256K metadata.json missing bundleID"; exit 1; }
+
+          MD_COUNT=$(find ./docs/P256K.doccarchive -name '*.md' | wc -l | tr -d ' ')
+          echo "P256K markdown file count: ${MD_COUNT}"
+          [ "$MD_COUNT" -gt 0 ] || { echo "::error::No P256K .md files found; --enable-experimental-markdown-output may have regressed"; exit 1; }
+
+      - name: Smoke-test P256K merge + static hosting
+        run: |
+          xcrun docc merge ./docs/P256K.doccarchive \
+            --output-path /tmp/p256k-merge-test.doccarchive
+          xcrun docc process-archive transform-for-static-hosting \
+            /tmp/p256k-merge-test.doccarchive \
+            --output-path /tmp/p256k-merge-test-static
+          test -f /tmp/p256k-merge-test-static/index.html
+          test -d /tmp/p256k-merge-test-static/documentation/p256k
+
+      - name: Build ZKP DocC Archive
+        env:
+          SOURCE_SERVICE_BASE_URL: "https://github.com/${{ github.repository }}/blob/${{ github.event.inputs.release_tag || github.ref_name }}"
+        run: |
+          swift package \
+            --allow-writing-to-directory ./docs \
+            generate-documentation \
+            --target ZKP \
+            --analyze \
+            --warnings-as-errors \
+            --enable-experimental-markdown-output \
+            --transform-for-static-hosting \
+            --experimental-transform-for-static-hosting-with-content \
+            --source-service github \
+            --source-service-base-url "$SOURCE_SERVICE_BASE_URL" \
+            --checkout-path "$GITHUB_WORKSPACE" \
+            --output-path ./docs/ZKP.doccarchive
+
+      - name: Sanity-check ZKP archive
+        run: |
+          test -d ./docs/ZKP.doccarchive
+          test -f ./docs/ZKP.doccarchive/metadata.json
+
+          BUNDLE_ID=$(jq -r '.bundleID // empty' ./docs/ZKP.doccarchive/metadata.json)
+          echo "ZKP bundle ID: ${BUNDLE_ID}"
+          [ -n "$BUNDLE_ID" ] || { echo "::error::ZKP metadata.json missing bundleID"; exit 1; }
+
+          MD_COUNT=$(find ./docs/ZKP.doccarchive -name '*.md' | wc -l | tr -d ' ')
+          echo "ZKP markdown file count: ${MD_COUNT}"
+          [ "$MD_COUNT" -gt 0 ] || { echo "::error::No ZKP .md files found"; exit 1; }
+
+      - name: Smoke-test ZKP merge + static hosting
+        run: |
+          xcrun docc merge ./docs/ZKP.doccarchive \
+            --output-path /tmp/zkp-merge-test.doccarchive
+          xcrun docc process-archive transform-for-static-hosting \
+            /tmp/zkp-merge-test.doccarchive \
+            --output-path /tmp/zkp-merge-test-static
+          test -f /tmp/zkp-merge-test-static/index.html
+          test -d /tmp/zkp-merge-test-static/documentation/zkp
+
+      - name: Zip both archives
+        run: |
+          cp LICENSE docs/LICENSE
+          cd docs
+          7z a -tzip -mx=9 P256K.doccarchive.zip P256K.doccarchive LICENSE
+          7z a -tzip -mx=9 ZKP.doccarchive.zip   ZKP.doccarchive   LICENSE
+
+      - name: Upload to Release
+        run: |
+          gh release upload "$RELEASE_TAG" docs/P256K.doccarchive.zip --clobber
+          gh release upload "$RELEASE_TAG" docs/ZKP.doccarchive.zip   --clobber
+
+      - name: Write step summary
+        # GitHub computes + exposes the asset SHA-256 automatically (visible on
+        # the release page + via `gh release view --json assets` .digest field).
+        # We hash inline here only for display in this job's step summary.
+        run: |
+          P256K_SIZE=$(ls -lh docs/P256K.doccarchive.zip | awk '{print $5}')
+          P256K_SHA=$(shasum -a 256 docs/P256K.doccarchive.zip | awk '{print $1}')
+          ZKP_SIZE=$(ls -lh docs/ZKP.doccarchive.zip | awk '{print $5}')
+          ZKP_SHA=$(shasum -a 256 docs/ZKP.doccarchive.zip | awk '{print $1}')
+          {
+            echo ""
+            echo "### DocC Release"
+            echo ""
+            echo "- **Release**: \`$RELEASE_TAG\`"
+            echo ""
+            echo "| Archive | Size | SHA-256 |"
+            echo "|---|---|---|"
+            echo "| \`P256K.doccarchive.zip\` | $P256K_SIZE | \`$P256K_SHA\` |"
+            echo "| \`ZKP.doccarchive.zip\` | $ZKP_SIZE | \`$ZKP_SHA\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ A Swift 6.1 wrapper around libsecp256k1 (and secp256k1-zkp) for the Bitcoin and 
 - **Xcode trait workaround**: Xcode does not resolve `.when(traits:)` for Swift settings. Source files use `#if Xcode || ENABLE_MODULE_*` guards — preserve these when editing.
 - **SharedSourcesPlugin**: Copies `Sources/Shared/*.swift` into both P256K and ZKP build directories. Changes to shared files affect both targets.
 - **Extraction flow**: Vendor → Sources via subtree CLI. Do not edit extracted paths directly; changes are overwritten on next extraction. See `Vendor/AGENTS.md`.
+- **Cross-archive DocC xrefs**: `SharedSourcesPlugin` copies the same source into P256K and ZKP archives, so disambiguation hashes (`signature(for:)-XXXXX`) differ per archive. Prefer unqualified `` `signature(for:)` `` code spans in `///` doc comments over symbol xrefs that would need per-archive hashes. See precedent in `Sources/Shared/HashDigest.swift`, `Sources/Shared/ECDSA/ECDSA+Signature.swift`.
+- **No `Snippets/` directory**: SwiftPM auto-discovered snippets (SE-0356) link every library product of the package. With two C-binding products (`libsecp256k1`, `libsecp256k1_zkp`) compiled from the same upstream source tree, any snippet produces duplicate C symbols at link time. Scoped snippet dependencies are a future direction per SE-0356; until SwiftPM ships them, documentation examples live as fenced ` ```swift` blocks inside catalog articles. Parked snippet sources from prior DocC work remain at `/tmp/swift-secp256k1-snippets-pending/P256K/` for future re-integration.
 
 ## Code Style
 

--- a/Sources/P256K/P256K.docc/GettingStarted.md
+++ b/Sources/P256K/P256K.docc/GettingStarted.md
@@ -6,7 +6,11 @@
 
 Learn how to generate keys, create ECDSA and Schnorr signatures, and perform ECDH key agreement using the P256K Swift library for the secp256k1 elliptic curve.
 
-## Adding P256K to Your Project
+## Overview
+
+This guide walks through the four most common P256K workflows end-to-end: adding the package, generating ECDSA and Schnorr key pairs, signing and verifying under each scheme, and performing ECDH key agreement. Follow the sections in order on your first read; each later section builds on types introduced earlier.
+
+### Adding P256K to Your Project
 
 Add `swift-secp256k1` as a Swift Package Manager dependency in your `Package.swift`:
 
@@ -32,13 +36,13 @@ Then import the module in your Swift files:
 import P256K
 ```
 
-## Understanding the Context
+### Understanding the Context
 
 Every cryptographic operation in P256K depends on a secp256k1 context object managed by ``P256K/Context``. The library provides a shared context via `P256K.Context.rawRepresentation` that is created and randomized automatically at process startup. You do not need to create or manage a context for standard use — the library handles this internally for every signing, verification, and key generation call.
 
 Context randomization seeds a blinding factor that protects ECDSA signing, Schnorr signing, and public key generation against timing and power analysis attacks. ECDH key agreement uses a different kind of elliptic curve point multiplication and does not currently benefit from context randomization.
 
-## Generating Key Pairs
+### Generating Key Pairs
 
 To create an ECDSA key pair, initialize a ``P256K/Signing/PrivateKey``. The private key generates the associated public key on demand:
 
@@ -59,7 +63,7 @@ let schnorrPrivateKey = try P256K.Schnorr.PrivateKey()
 let xonlyPublicKey = schnorrPrivateKey.xonly
 ```
 
-## Signing and Verifying with ECDSA
+### Signing and Verifying with ECDSA
 
 ``P256K/Signing/PrivateKey`` signs arbitrary data directly. SHA-256 is applied internally before calling `secp256k1_ecdsa_sign`. The resulting 64-byte signature is in normalized lower-S form, which is the only form accepted by `secp256k1_ecdsa_verify`:
 
@@ -90,7 +94,7 @@ let compactSignature = signature.compactRepresentation
 let parsed = try P256K.Signing.ECDSASignature(compactRepresentation: compactSignature)
 ```
 
-## Signing and Verifying with Schnorr
+### Signing and Verifying with Schnorr
 
 ``P256K/Schnorr/PrivateKey`` signs hash digests and produces 64-byte Schnorr signatures as defined by BIP-340. Schnorr signatures are verified using an ``P256K/Schnorr/XonlyKey``, which contains only the x-coordinate of the public key:
 
@@ -109,7 +113,7 @@ let isValid = schnorrKey.xonly.isValidSignature(schnorrSignature, for: digest)
 print(isValid) // true
 ```
 
-## Performing ECDH Key Agreement
+### Performing ECDH Key Agreement
 
 ``P256K/KeyAgreement/PrivateKey`` performs Elliptic Curve Diffie-Hellman (ECDH) key agreement using `secp256k1_ecdh`. Both parties derive an identical ``SharedSecret`` from their own private key and the other party's public key, without transmitting the secret:
 
@@ -131,7 +135,7 @@ let bobSharedSecret = bobPrivateKey.sharedSecretFromKeyAgreement(with: alicePubl
 
 > Note: Context randomization does not provide side-channel protection for ECDH. The ECDH module uses a different kind of elliptic curve point multiplication that does not currently benefit from base point blinding.
 
-## Next Steps
+### Next Steps
 
 - **MuSig2 multi-signatures**: Use ``P256K/MuSig`` to aggregate public keys and produce a single Schnorr signature from multiple independent signers, as defined by BIP-327.
 - **ECDSA key recovery**: Use ``P256K/Recovery`` to recover a public key from a recoverable ECDSA signature and recovery ID.

--- a/Sources/P256K/P256K.docc/KeyFormats.md
+++ b/Sources/P256K/P256K.docc/KeyFormats.md
@@ -6,11 +6,15 @@
 
 Understand why secp256k1 has multiple key representations and when to use each one.
 
-## Elliptic Curve Points
+## Overview
+
+secp256k1 public keys can be serialized in four distinct formats — compressed (33 bytes), uncompressed (65 bytes), x-only (32 bytes), and the internal libsecp256k1 `secp256k1_pubkey` structure. Each has a specific use case and interoperability story. This article explains the mathematical relationship between them, which format each Bitcoin / Lightning / Nostr protocol expects, and how to pick one for your application.
+
+### Elliptic Curve Points
 
 A secp256k1 public key is a point `(x, y)` on the elliptic curve. Both coordinates are 256-bit (32-byte) integers. Since the curve equation `y^2 = x^3 + 7` has exactly two solutions for each `x` value (one even, one odd), you only need the `x` coordinate plus a single bit to identify the point uniquely.
 
-## Compressed Keys (33 bytes)
+### Compressed Keys (33 bytes)
 
 The **compressed** format stores the x-coordinate with a one-byte prefix indicating the parity of y:
 
@@ -25,7 +29,7 @@ key.publicKey.dataRepresentation.count    // 33
 key.publicKey.format                      // .compressed
 ```
 
-## Uncompressed Keys (65 bytes)
+### Uncompressed Keys (65 bytes)
 
 The **uncompressed** format stores both coordinates with a `0x04` prefix:
 
@@ -37,7 +41,7 @@ key.publicKey.format                      // .uncompressed
 
 Uncompressed keys are rarely used in modern Bitcoin but appear in legacy transactions and some non-Bitcoin protocols. P256K supports them for interoperability.
 
-## X-Only Keys (32 bytes)
+### X-Only Keys (32 bytes)
 
 BIP-340 introduced **x-only** public keys for Schnorr signatures. These are simply the 32-byte x-coordinate with no prefix byte. The y-coordinate is implicitly defined as the **even** value.
 
@@ -51,7 +55,7 @@ X-only keys save 1 byte per public key and simplify the Schnorr verification equ
 - BIP-341 Taproot output keys
 - BIP-327 MuSig2 aggregate keys
 
-## Key Parity
+### Key Parity
 
 The `parity` property on x-only key types indicates whether the full point's y-coordinate is odd (`true`) or even (`false`).
 
@@ -61,7 +65,7 @@ Parity matters when:
 - **Taproot tweak verification** -- You need to know whether the internal key was negated during output key derivation.
 - **MuSig2 key aggregation** -- The aggregate key's parity affects how partial signatures are combined.
 
-## The Format Enum
+### The Format Enum
 
 ``P256K/Format`` controls key serialization:
 
@@ -72,7 +76,7 @@ Parity matters when:
 
 The `rawValue` maps directly to the flag passed to the underlying C library's serialization functions.
 
-## Choosing a Format
+### Choosing a Format
 
 - **Default to compressed** for all new applications. It is the standard for Bitcoin, smaller, and fully supported.
 - **Use x-only** when working with Schnorr signatures, Taproot, or MuSig2.

--- a/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
+++ b/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
@@ -10,7 +10,7 @@ Create a single Schnorr signature from multiple independent signers using the BI
 
 MuSig2 allows multiple parties to produce a single compact Schnorr signature that verifies against an aggregated public key. No observer can distinguish a MuSig2 signature from a regular Schnorr signature. This guide walks through the complete signing protocol.
 
-## Aggregating Public Keys
+### Aggregating Public Keys
 
 Each signer generates a Schnorr key pair. The public keys are then aggregated into a single ``P256K/MuSig/PublicKey``:
 
@@ -28,7 +28,7 @@ let aggregate = try P256K.MuSig.aggregate([
 
 Key aggregation is order-independent -- the same aggregate is produced regardless of the order the public keys are provided.
 
-## Generating Nonces
+### Generating Nonces
 
 Each signer independently generates a nonce pair. The `generate` function returns a ``P256K/Schnorr/SecureNonce`` (the secret nonce) and a public nonce:
 
@@ -45,7 +45,7 @@ let aliceNonce = try P256K.MuSig.Nonce.generate(
 
 > Warning: A `SecureNonce` is `~Copyable` by design. Using the same secret nonce in two different signing sessions **leaks the signing key**. The type system prevents accidental reuse.
 
-## Aggregating Nonces
+### Aggregating Nonces
 
 Each signer shares their public nonce. Once all public nonces are collected, aggregate them:
 
@@ -55,7 +55,7 @@ let aggregateNonce = try P256K.MuSig.Nonce(aggregating: [
 ])
 ```
 
-## Creating Partial Signatures
+### Creating Partial Signatures
 
 Each signer creates a partial signature using their private key, their secret nonce, and the aggregated nonce:
 
@@ -69,7 +69,7 @@ let alicePartial = try alice.partialSignature(
 )
 ```
 
-## Aggregating Signatures
+### Aggregating Signatures
 
 Once all partial signatures are collected, aggregate them into the final Schnorr signature:
 
@@ -79,7 +79,7 @@ let finalSignature = try P256K.MuSig.aggregateSignatures([
 ])
 ```
 
-## Verification
+### Verification
 
 The final signature verifies against the aggregated x-only public key, just like any BIP-340 Schnorr signature:
 

--- a/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
+++ b/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
@@ -6,7 +6,11 @@
 
 Recover an ECDSA public key from a recoverable signature and its recovery ID.
 
-## Creating a Recoverable Signature
+## Overview
+
+ECDSA recoverable signatures attach a small (1–3 bit) **recovery ID** to a signature, letting verifiers reconstruct the signing public key from the signature and message alone. This saves one round trip in account-discovery flows and underpins Bitcoin signed-message workflows — [BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki) (legacy `signmessage`/`verifymessage` in Bitcoin Core) and [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki) (generic signed-message format). The sections below walk through creating, serializing, and recovering keys from recoverable signatures, and converting them to standard ECDSA signatures for use with APIs that expect the vanilla form.
+
+### Creating a Recoverable Signature
 
 Use ``P256K/Recovery/PrivateKey`` to produce a recoverable ECDSA signature. Unlike standard ECDSA signatures, recoverable signatures include a recovery ID that identifies which of up to four candidate public keys produced the signature:
 
@@ -19,7 +23,7 @@ let message = "We're all Satoshi.".data(using: .utf8)!
 let recoverySignature = privateKey.signature(for: message)
 ```
 
-## Recovering the Public Key
+### Recovering the Public Key
 
 Recover the signer's public key from the message and recoverable signature:
 
@@ -37,7 +41,7 @@ let digest = SHA256.hash(data: message)
 let recoveredKey = P256K.Recovery.PublicKey(digest, signature: recoverySignature)
 ```
 
-## Compact Representation and Recovery ID
+### Compact Representation and Recovery ID
 
 A recoverable signature can be serialized as a compact representation (64 bytes) plus a separate recovery ID (0-3):
 
@@ -56,7 +60,7 @@ let restored = try P256K.Recovery.ECDSASignature(
 )
 ```
 
-## Converting to Standard ECDSA
+### Converting to Standard ECDSA
 
 Use the ``P256K/Recovery/ECDSASignature/normalize`` property to convert a recoverable signature to a standard ECDSA signature:
 
@@ -68,4 +72,4 @@ standardSignature.dataRepresentation   // 64-byte compact
 standardSignature.derRepresentation    // DER-encoded
 ```
 
-> Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's BIP-62 rule 6), call ``P256K/Signing/ECDSASignature/normalize`` on the result.
+> Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's BIP-62 rule 6), pass the result through `secp256k1_ecdsa_signature_normalize` before verifying.

--- a/Sources/P256K/P256K.docc/SecurityConsiderations.md
+++ b/Sources/P256K/P256K.docc/SecurityConsiderations.md
@@ -6,7 +6,11 @@
 
 Understand the security properties of P256K and how to avoid common cryptographic pitfalls.
 
-## Context Randomization
+## Overview
+
+P256K layers a Swift API over [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1), which is engineered for constant-time execution and side-channel resistance on the private-key paths. The sections below cover the areas where application code can still make mistakes that weaken those guarantees: context randomization lifecycle, nonce hygiene, comparison timing, secret zeroization, and ECDSA signature malleability.
+
+### Context Randomization
 
 Every cryptographic operation in P256K depends on a secp256k1 context managed by ``P256K/Context``. The shared context is created and **randomized** once at process startup using OS-provided entropy.
 
@@ -14,7 +18,7 @@ Randomization seeds a blinding factor that protects **ECDSA signing**, **Schnorr
 
 > Note: ECDH key agreement uses a different kind of elliptic curve point multiplication and does **not** currently benefit from context randomization.
 
-## Nonce Reuse
+### Nonce Reuse
 
 The most dangerous mistake in elliptic curve cryptography is reusing a nonce (random value) across two different signing operations with the same private key. If the same nonce `k` is used to sign two different messages, an attacker can compute the private key from the two signatures using simple algebra.
 
@@ -43,7 +47,7 @@ let partial = try privateKey.partialSignature(
 
 For standard (non-MuSig) ECDSA and Schnorr signing, P256K uses deterministic nonce generation (RFC 6979 for ECDSA, BIP-340 for Schnorr) by default, which eliminates the risk of random nonce reuse entirely.
 
-## Constant-Time Comparison
+### Constant-Time Comparison
 
 When comparing secret values (shared secrets, keys, signatures), use constant-time comparison to avoid timing side-channels. P256K's ``SharedSecret`` type uses constant-time equality internally:
 
@@ -57,12 +61,12 @@ secret1 == secret2
 
 Never compare secret bytes using standard `==` on `Data` or `[UInt8]`, as this may short-circuit on the first differing byte, leaking information about which bytes match.
 
-## Secret Key Zeroization
+### Secret Key Zeroization
 
 P256K uses `SecureBytes` internally for private key storage. When a `SecureBytes` value is deallocated, its memory is overwritten with zeros using `memset_s` (or an equivalent that the compiler cannot optimize away). This prevents secret key material from lingering in memory after the key object is destroyed.
 
-## ECDSA Signature Malleability
+### ECDSA Signature Malleability
 
 An ECDSA signature `(r, s)` has a counterpart `(r, n - s)` that is also valid for the same message and public key. This **malleability** can cause problems in systems that use the signature as a unique transaction identifier (e.g., Bitcoin before SegWit).
 
-P256K enforces **lower-S normalization** (BIP-62 rule 6): `secp256k1_ecdsa_verify` only accepts signatures where `s` is in the lower half of the curve order. The ``P256K/Signing/PrivateKey/signature(for:)-1hf2o`` method always produces normalized signatures, and ``P256K/Recovery/ECDSASignature/normalize`` converts recoverable signatures to the canonical form.
+P256K enforces **lower-S normalization** (BIP-62 rule 6): `secp256k1_ecdsa_verify` only accepts signatures where `s` is in the lower half of the curve order. The `signature(for:)` overloads on ``P256K/Signing/PrivateKey`` always produce normalized signatures, and the `normalize` property on a recoverable signature (``P256K/Recovery/ECDSASignature``) converts it to the canonical form.

--- a/Sources/P256K/P256K.docc/SerializingKeys.md
+++ b/Sources/P256K/P256K.docc/SerializingKeys.md
@@ -6,7 +6,11 @@
 
 Import and export keys in raw bytes, PEM, DER, and other standard formats.
 
-## Raw Bytes
+## Overview
+
+Key serialization comes up in wallet storage, protocol interop (`EC PRIVATE KEY` / `PRIVATE KEY` PEM envelopes, X.509 SubjectPublicKeyInfo DER), and on-the-wire Bitcoin/Lightning witness data. The sections below cover each supported format in the order you will typically encounter them.
+
+### Raw Bytes
 
 The most common serialization. Use `dataRepresentation` to export and `init(dataRepresentation:format:)` to import:
 
@@ -28,7 +32,7 @@ let privKeyData = privateKey.dataRepresentation  // 32 bytes
 let restored = try P256K.Signing.PrivateKey(dataRepresentation: privKeyData)
 ```
 
-## PEM Encoding
+### PEM Encoding
 
 Import keys from PEM-encoded strings. Both SEC1 (`EC PRIVATE KEY`) and PKCS#8 (`PRIVATE KEY`) formats are supported:
 
@@ -49,7 +53,7 @@ Public keys use the `PUBLIC KEY` PEM type:
 let publicKey = try P256K.Signing.PublicKey(pemRepresentation: publicKeyPEM)
 ```
 
-## DER Encoding
+### DER Encoding
 
 Import from DER-encoded binary data:
 
@@ -65,7 +69,7 @@ let signature = try P256K.Signing.ECDSASignature(derRepresentation: derData)
 let derBytes = signature.derRepresentation
 ```
 
-## Compressed vs Uncompressed
+### Compressed vs Uncompressed
 
 Specify the format when creating keys:
 
@@ -85,7 +89,7 @@ Convert a compressed public key to its uncompressed form:
 let fullBytes = compressedPublicKey.uncompressedRepresentation  // 65 bytes
 ```
 
-## X-Only Keys
+### X-Only Keys
 
 Schnorr signatures (BIP-340) use 32-byte x-only public keys with implicit even parity:
 
@@ -104,7 +108,7 @@ let xonly = ecdsaPublicKey.xonly
 let fullKey = P256K.Signing.PublicKey(xonlyKey: xonly)
 ```
 
-## Format Comparison
+### Format Comparison
 
 | Format | Size | Prefix | Use Case |
 |--------|------|--------|----------|

--- a/Sources/P256K/P256K.docc/TweakingKeys.md
+++ b/Sources/P256K/P256K.docc/TweakingKeys.md
@@ -6,7 +6,11 @@
 
 Derive child keys using additive and multiplicative tweaks for BIP-32 key derivation and BIP-341 Taproot.
 
-## ECDSA Key Tweaking
+## Overview
+
+Tweaking combines an existing key pair with a scalar offset to produce a new key pair while preserving the linear relationship between private and public halves. This is the algebraic foundation of [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) hierarchical deterministic wallets and [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) Taproot output-key derivation. The sections below cover each signature family's tweak API.
+
+### ECDSA Key Tweaking
 
 Tweak an ECDSA private key by adding a scalar, producing a new key pair. This is the basis of BIP-32 hierarchical deterministic key derivation:
 
@@ -31,7 +35,7 @@ let tweakedPublicKey = try publicKey.add(Array(tweak))
 let tweakedByMul = try publicKey.multiply(Array(tweak))
 ```
 
-## Schnorr Key Tweaking
+### Schnorr Key Tweaking
 
 Schnorr keys use x-only (32-byte) public keys with implicit even parity. Tweaking a Schnorr key handles the parity adjustment automatically:
 
@@ -48,7 +52,7 @@ X-only public keys can also be tweaked directly:
 let tweakedXonly = try schnorrKey.xonly.add(Array(tweak))
 ```
 
-## Taproot Output Key Construction
+### Taproot Output Key Construction
 
 BIP-341 Taproot derives an output key from an internal key using a tagged hash tweak. For a key-path-only output (no script tree):
 
@@ -78,7 +82,7 @@ let tweakHash = SHA256.taggedHash(
 let outputKey = try internalKey.add(Array(tweakHash))
 ```
 
-## MuSig Aggregate Key Tweaking
+### MuSig Aggregate Key Tweaking
 
 Aggregated MuSig2 keys can be tweaked for BIP-32 derivation or Taproot:
 

--- a/Sources/Shared/Combine.swift
+++ b/Sources/Shared/Combine.swift
@@ -18,17 +18,30 @@ import Foundation
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K.Signing.PublicKey {
-    /// Creates a new ``PublicKey`` by adding this key together with `pubkeys` via `secp256k1_ec_pubkey_combine`, equivalent to point addition on the secp256k1 curve.
+    /// Creates a new ``PublicKey`` by adding this key together with `pubkeys` via
+    /// `secp256k1_ec_pubkey_combine` (declared in
+    /// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h)),
+    /// equivalent to point addition on the secp256k1 curve.
     ///
-    /// Point addition is the basis for unhardened BIP-32 child public key derivation and for
-    /// constructing multisig output keys without revealing individual private keys. The result
-    /// equals `G × (sk₀ + sk₁ + … + skₙ)` if each input key was derived from its corresponding
-    /// private key, making it useful for verifying that a set of keys sums to a known aggregate.
+    /// Point addition is the basis for unhardened
+    /// [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) child public-
+    /// key derivation and for constructing multisig output keys without revealing individual
+    /// private keys. The result equals `G × (sk₀ + sk₁ + … + skₙ)` if each input key was
+    /// derived from its corresponding private key, making it useful for verifying that a set
+    /// of keys sums to a known aggregate.
     ///
-    /// - Parameter pubkeys: Additional ``PublicKey`` values to combine with this key; must contain at least one key.
-    /// - Parameter format: The serialization format of the returned ``PublicKey``; defaults to `.compressed`.
+    /// > Important: Use ``P256K/MuSig/aggregate(_:)`` instead when you need a BIP-327
+    /// > MuSig2 aggregate key for collaborative signing — MuSig2 aggregation is **not** plain
+    /// > point addition, and using `combine` in its place produces a key that no participant
+    /// > can sign against.
+    ///
+    /// - Parameter pubkeys: Additional ``PublicKey`` values to combine with this key; must
+    ///   contain at least one key. (Upstream requires `n ≥ 1`.)
+    /// - Parameter format: The serialization format of the returned ``PublicKey``; defaults
+    ///   to `.compressed`.
     /// - Returns: A new ``PublicKey`` equal to the elliptic-curve sum of all input keys.
-    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if `secp256k1_ec_pubkey_combine` fails (e.g., all keys cancel to the point at infinity).
+    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if `secp256k1_ec_pubkey_combine`
+    ///   fails (e.g., all keys cancel to the point at infinity).
     func combine(_ pubkeys: [Self], format: P256K.Format = .compressed) throws -> Self {
         let context = P256K.Context.rawRepresentation
         let allPubKeys = [self] + pubkeys

--- a/Sources/Shared/Context.swift
+++ b/Sources/Shared/Context.swift
@@ -14,12 +14,14 @@
     import libsecp256k1
 #endif
 
-/// Context management for the secp256k1 elliptic curve used in ECDSA signing, Schnorr signatures, and key generation.
+/// Context management for the secp256k1 elliptic curve used in ECDSA signing, Schnorr signatures,
+/// and key generation.
 ///
 /// This extension provides the ``Context`` structure, which manages the lifecycle and randomization
-/// of the `secp256k1` context object that all cryptographic operations in the library depend on,
+/// of the `secp256k1_context` object that all cryptographic operations in the library depend on,
 /// including ECDSA signature creation and verification, Schnorr signature operations, public key
-/// generation, and elliptic curve Diffie-Hellman (ECDH) key agreement.
+/// generation, and ECDH key agreement. The upstream reference is
+/// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h).
 ///
 /// Use ``Context/rawRepresentation`` to access the shared, pre-initialized context for standard
 /// operations, or call ``Context/create()`` to create a fresh, independently randomized context.
@@ -30,11 +32,13 @@
 /// during operations that multiply a secret scalar with the elliptic curve base point, such as
 /// ECDSA signing, Schnorr signing, and public key generation. This protection is only effective
 /// when the context is randomized after creation, which ``Context/create()`` handles automatically
-/// using cryptographically secure random bytes.
+/// using 32 bytes of cryptographically secure randomness drawn via `SecureBytes`.
 ///
-/// The ECDH module relies on a different kind of elliptic curve point multiplication and does not
-/// currently benefit from this enhanced side-channel protection, even when using a randomized
-/// context.
+/// Per the upstream `secp256k1_context_randomize` documentation:
+/// *"A notable exception to that rule is the ECDH module, which relies on a different kind of
+/// elliptic curve point multiplication and thus does not benefit from enhanced protection against
+/// side-channel leakage currently."* Consumers needing hardened ECDH should look beyond context
+/// randomization.
 ///
 /// ## Thread Safety
 ///
@@ -84,6 +88,14 @@ public extension P256K {
     /// point, including ECDSA signing, Schnorr signing, and public key generation. The ECDH module
     /// uses a different kind of point multiplication and does not currently benefit from context
     /// randomization.
+    ///
+    /// ## Topics
+    ///
+    /// ### Shared Context
+    /// - ``rawRepresentation``
+    ///
+    /// ### Construction
+    /// - ``create()``
     struct Context: Sendable {
         /// The shared secp256k1 context, created and randomized at initialization for use across all P256K cryptographic operations.
         ///
@@ -105,8 +117,8 @@ public extension P256K {
         /// Creates a new secp256k1 context and randomizes it with cryptographically secure bytes for side-channel protection.
         ///
         /// This method allocates a new secp256k1 context using `secp256k1_context_create` with the
-        /// ``rawValue`` flags, then calls `secp256k1_context_randomize` with 32 bytes of secure
-        /// randomness from ``SecureBytes``. Randomization seeds an internal counter that blinds
+        /// context's `rawValue` flags, then calls `secp256k1_context_randomize` with 32 bytes of secure
+        /// randomness from the internal `SecureBytes` wrapper. Randomization seeds an internal counter that blinds
         /// intermediate values during secret scalar multiplication with the elliptic curve base
         /// point, protecting ECDSA signing, Schnorr signing, and public key generation against
         /// timing and power analysis attacks.

--- a/Sources/Shared/ECDH.swift
+++ b/Sources/Shared/ECDH.swift
@@ -22,49 +22,130 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K {
-        /// secp256k1 ECDH key agreement namespace providing ``PrivateKey`` and ``PublicKey`` for computing a ``SharedSecret`` via `secp256k1_ecdh`.
+        /// secp256k1 ECDH (Elliptic-Curve Diffie-Hellman) key-agreement namespace
+        /// providing ``PrivateKey`` and ``PublicKey`` for computing a ``SharedSecret`` via
+        /// `secp256k1_ecdh` (declared in
+        /// [`Vendor/secp256k1/include/secp256k1_ecdh.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_ecdh.h)).
+        ///
+        /// ## Overview
         ///
         /// ECDH computes a shared secret `S = private_key × peer_public_key` on the secp256k1
-        /// elliptic curve. **Context randomization does not provide side-channel protection for
-        /// ECDH** — it uses a different kind of point multiplication than ECDSA or Schnorr signing.
-        /// The shared secret is returned as a serialized point in compressed (33-byte, default)
-        /// or uncompressed (65-byte) form depending on the `format` argument.
+        /// elliptic curve. The upstream C function executes in constant time with respect to
+        /// the secret scalar, matching its contract line: *"Compute an EC Diffie-Hellman secret
+        /// in constant time."* The shared secret is returned as a serialized point in
+        /// compressed (33-byte, default) or uncompressed (65-byte) form via the custom hash
+        /// closure installed in ``PrivateKey/sharedSecretFromKeyAgreement(with:format:)`` —
+        /// this overrides the upstream default (`secp256k1_ecdh_hash_function_sha256`, which
+        /// would return a 32-byte SHA-256 hash of the compressed point) so callers receive the
+        /// raw serialized EC point, suitable as input to any higher-level KDF.
+        ///
+        /// Bitcoin-ecosystem consumers include BIP-324 v2 P2P transport
+        /// ([BIP-324](https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki)),
+        /// BIP-352 Silent Payments
+        /// ([BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)),
+        /// and Lightning Network session-key derivation.
+        ///
+        /// > Important: **Context randomization does not provide side-channel protection for
+        /// > ECDH.** Per the upstream `secp256k1_context_randomize` documentation in
+        /// > [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h):
+        /// > *"A notable exception [to the rule that randomization protects secret-key
+        /// > operations] is the ECDH module, which relies on a different kind of elliptic
+        /// > curve point multiplication and thus does not benefit from enhanced protection
+        /// > against side-channel leakage currently."* Consumers needing hardened ECDH should
+        /// > perform it on an air-gapped device or with platform-specific mitigations.
+        ///
+        /// ## Topics
+        ///
+        /// ### Key Types
+        /// - ``PrivateKey``
+        /// - ``PublicKey``
+        /// - ``XonlyKey``
         enum KeyAgreement: Sendable {
-            /// secp256k1 ECDH public key, accepted by ``PrivateKey/sharedSecretFromKeyAgreement(with:format:)`` to compute a ``SharedSecret``.
+            /// secp256k1 ECDH public key, accepted by
+            /// ``PrivateKey/sharedSecretFromKeyAgreement(with:format:)`` to compute a
+            /// ``SharedSecret``.
+            ///
+            /// Semantically the same 33- or 65-byte SEC1 encoded public key used by ECDSA
+            /// and Schnorr; the Swift type is distinct only so that the compiler routes
+            /// calls to the ECDH-specific Diffie-Hellman method instead of a signing API.
+            ///
+            /// ## Topics
+            ///
+            /// ### Construction
+            /// - ``init(dataRepresentation:format:)``
+            /// - ``init(x963Representation:)``
+            /// - ``init(derRepresentation:)``
+            ///
+            /// ### Serialized Forms
+            /// - ``dataRepresentation``
+            /// - ``uncompressedRepresentation``
+            /// - ``xonly``
             public struct PublicKey: Sendable {
-                /// The internal backing public key implementation.
+                /// The internal `PublicKeyImplementation` backing this ECDH public key.
+                ///
+                /// Kept `internal` — the backing type wraps the 64-byte upstream
+                /// `secp256k1_pubkey` struct plus serialization format; consumers never see
+                /// the raw C handle through the public API.
                 let baseKey: PublicKeyImplementation
 
                 /// Creates a secp256k1 ECDH public key from serialized bytes.
                 ///
-                /// - Parameter data: Serialized public key bytes whose length must match `format.length`.
-                /// - Parameter format: The serialization format; defaults to `.compressed` (33 bytes).
-                /// - Throws: ``secp256k1Error/underlyingCryptoError`` if parsing via `secp256k1_ec_pubkey_parse` fails.
+                /// - Parameter data: Serialized public key bytes whose length must match
+                ///   `format.length` (33 for compressed, 65 for uncompressed).
+                /// - Parameter format: The serialization format; defaults to `.compressed`
+                ///   (33 bytes).
+                /// - Throws: ``secp256k1Error/underlyingCryptoError`` if parsing via
+                ///   `secp256k1_ec_pubkey_parse` fails (invalid encoding or off-curve point).
                 public init<D: ContiguousBytes>(dataRepresentation data: D, format: P256K.Format = .compressed) throws {
                     self.baseKey = try PublicKeyImplementation(dataRepresentation: data, format: format)
                 }
 
                 /// Creates an ECDH public key from a validated backing implementation.
+                ///
+                /// Internal-visibility constructor used by the companion ``PrivateKey``'s
+                /// ``PrivateKey/publicKey`` accessor after the backing implementation has
+                /// already been validated.
+                ///
+                /// - Parameter baseKey: A validated `PublicKeyImplementation` produced by
+                ///   the upstream C parser.
                 init(baseKey: PublicKeyImplementation) {
                     self.baseKey = baseKey
                 }
 
                 /// The 32-byte x-only public key (X coordinate only) derived from this key.
+                ///
+                /// Computed on every access via `secp256k1_xonly_pubkey_from_pubkey`. Useful
+                /// when a downstream protocol (Taproot-aware ECDH schemes, Silent Payments)
+                /// needs the BIP-340-style x-only representation of the same public point.
                 public var xonly: P256K.KeyAgreement.XonlyKey {
                     XonlyKey(baseKey: baseKey.xonly)
                 }
 
-                /// The 65-byte uncompressed serialization of this public key (0x04 prefix + X + Y).
+                /// The 65-byte uncompressed serialization of this public key (`0x04` prefix
+                /// + 32-byte X + 32-byte Y).
+                ///
+                /// Always returns the uncompressed form regardless of the key's stored
+                /// ``P256K/Format``. Useful when interoperating with systems that require
+                /// the full `(x, y)` point encoding.
                 public var uncompressedRepresentation: Data {
                     baseKey.uncompressedRepresentation
                 }
 
-                /// The serialized public key bytes as `Data`, in the key's format.
+                /// The serialized public key bytes as `Data`, in the key's
+                /// ``P256K/Format``.
+                ///
+                /// Suitable for transmission and persistence. Format is the one passed at
+                /// construction time and can be inspected via the backing implementation's
+                /// `format` property when needed.
                 public var dataRepresentation: Data {
                     baseKey.dataRepresentation
                 }
 
                 /// The serialized public key bytes as `[UInt8]`.
+                ///
+                /// Internal-visibility accessor used by peer-facing Swift helpers that want
+                /// to avoid the `Data` allocation; external callers use
+                /// ``dataRepresentation`` for the `Data` form.
                 var bytes: [UInt8] {
                     baseKey.bytes
                 }
@@ -99,30 +180,86 @@ public import Foundation
                 }
             }
 
-            /// The 32-byte x-only form of a ``PublicKey``, derived via `secp256k1_xonly_pubkey_from_pubkey`.
+            /// The 32-byte x-only form of a ``PublicKey``, derived via
+            /// `secp256k1_xonly_pubkey_from_pubkey`.
+            ///
+            /// Drops the Y-coordinate parity bit from the 33-byte compressed encoding,
+            /// matching the BIP-340 x-only representation. The 1-bit parity is preserved
+            /// separately in ``parity`` so Taproot-aware ECDH schemes can reconstruct the
+            /// full point when needed.
+            ///
+            /// ## Topics
+            ///
+            /// ### Inspection
+            /// - ``dataRepresentation``
+            /// - ``parity``
             public struct XonlyKey: Sendable {
-                /// The internal backing x-only key implementation.
+                /// The internal `XonlyKeyImplementation` backing this x-only key.
+                ///
+                /// Kept `private` — the backing type is an internal convenience over the
+                /// upstream `secp256k1_xonly_pubkey` struct; consumers never see or
+                /// manipulate it directly.
                 private let baseKey: XonlyKeyImplementation
 
                 /// The 32-byte X coordinate as `Data`.
+                ///
+                /// Stable across libsecp256k1 versions — safe to persist as a BIP-340-style
+                /// key identifier. Pair with ``parity`` when the full `(x, y)` point must
+                /// be reconstructed downstream.
                 public var dataRepresentation: Data {
                     baseKey.dataRepresentation
                 }
 
-                /// `true` if the full public key's Y coordinate is odd (the x-only point is the negation of the original pubkey), `false` if even; as returned by `secp256k1_xonly_pubkey_from_pubkey`.
+                /// `true` if the full public key's Y coordinate is odd (the x-only point is
+                /// the negation of the original pubkey), `false` if even; as returned by
+                /// `secp256k1_xonly_pubkey_from_pubkey`.
+                ///
+                /// BIP-340 verifiers operate against the even-Y representative of a point,
+                /// so the parity bit is tracked separately. `true` means the original
+                /// pubkey had odd Y and had its sign flipped during x-only conversion.
                 public var parity: Bool {
                     baseKey.keyParity.boolValue
                 }
 
                 /// Creates an ECDH x-only key from a validated backing implementation.
+                ///
+                /// Internal-visibility constructor used by ``PublicKey/xonly``; consumers
+                /// access x-only keys through that accessor rather than constructing
+                /// directly.
+                ///
+                /// - Parameter baseKey: A validated `XonlyKeyImplementation`.
                 init(baseKey: XonlyKeyImplementation) {
                     self.baseKey = baseKey
                 }
             }
 
-            /// secp256k1 ECDH private key for deriving a ``SharedSecret`` with a peer's ``PublicKey`` via `secp256k1_ecdh`.
+            /// secp256k1 ECDH private key for deriving a ``SharedSecret`` with a peer's
+            /// ``PublicKey`` via `secp256k1_ecdh`.
+            ///
+            /// The underlying 32-byte scalar is identical to an ECDSA or Schnorr private
+            /// key on the same curve; the Swift type is distinct only to route calls to
+            /// the Diffie-Hellman method surface instead of a signing API. Secret bytes are
+            /// held in `SecureBytes`-style zeroizing storage via the backing
+            /// `PrivateKeyImplementation`.
+            ///
+            /// ## Topics
+            ///
+            /// ### Construction
+            /// - ``init(format:)``
+            /// - ``init(dataRepresentation:format:)``
+            ///
+            /// ### Inspection
+            /// - ``publicKey``
+            /// - ``rawRepresentation``
+            ///
+            /// ### Key Agreement
+            /// - ``sharedSecretFromKeyAgreement(with:format:)``
             public struct PrivateKey: Sendable {
-                /// The internal backing private key implementation.
+                /// The internal `PrivateKeyImplementation` backing this ECDH signing key.
+                ///
+                /// Kept `internal` — the backing type wraps the 32-byte secret scalar in
+                /// `SecureBytes`-style zeroizing storage; consumers interact only through
+                /// the public API surface and the DH protocol conformance.
                 let baseKey: PrivateKeyImplementation
 
                 /// Creates a random secp256k1 ECDH private key.
@@ -147,17 +284,34 @@ public import Foundation
                     self.baseKey = baseKey
                 }
 
-                /// The secp256k1 public key derived from this private key.
+                /// The secp256k1 public key derived from this private key, as a
+                /// ``PublicKey``.
+                ///
+                /// Computed on every access via `secp256k1_ec_pubkey_create`. For
+                /// high-frequency key-agreement loops, cache the value locally rather than
+                /// re-deriving it per call. The returned public key carries the private
+                /// key's ``P256K/Format`` selection.
                 public var publicKey: P256K.KeyAgreement.PublicKey {
                     PublicKey(baseKey: baseKey.publicKey)
                 }
 
-                /// The raw 32-byte private key as `Data`. Keep this value confidential.
+                /// The raw 32-byte private key as `Data`. Keep this value confidential;
+                /// disclosure allows anyone to compute shared secrets with this key.
+                ///
+                /// The bytes are zeroed when the backing `PrivateKeyImplementation` is
+                /// deallocated, but **copies made through this accessor are not**: any
+                /// `Data` produced here escapes the zeroization scope and must be handled
+                /// by the caller. Prefer restricting its reach to the minimum necessary
+                /// scope (e.g. one encrypted write to a keychain) before discarding.
                 public var rawRepresentation: Data {
                     baseKey.dataRepresentation
                 }
 
                 /// The raw 32-byte private key as `SecureBytes`.
+                ///
+                /// Internal-visibility accessor used by Swift-side helpers that participate
+                /// in the `SecureBytes` lifetime; external callers use ``rawRepresentation``
+                /// for a `Data` copy.
                 var bytes: SecureBytes {
                     baseKey.key
                 }
@@ -169,7 +323,15 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     extension P256K.KeyAgreement.PrivateKey: DiffieHellmanKeyAgreement {
-        /// The C function type for a custom ECDH hash function that serializes the shared EC point into secret bytes.
+        /// The C function type for a custom ECDH hash function that serializes the shared
+        /// EC point into secret bytes.
+        ///
+        /// Matches the upstream `secp256k1_ecdh_hash_function` typedef in
+        /// [`Vendor/secp256k1/include/secp256k1_ecdh.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_ecdh.h).
+        /// The installed closure receives the 32-byte `x` and `y` coordinates of the
+        /// shared point along with a user-data pointer; the upstream contract requires
+        /// returning `1` on success (allowing `secp256k1_ecdh` itself to return `1`) and
+        /// `0` on failure (which propagates as `secp256k1_ecdh` returning `0`).
         public typealias HashFunctionType = @convention(c) (
             UnsafeMutablePointer<UInt8>?,
             UnsafePointer<UInt8>?,
@@ -177,7 +339,12 @@ public import Foundation
             UnsafeMutableRawPointer?
         ) -> Int32
 
-        /// Computes a compressed-format ECDH shared secret with `publicKeyShare` via `secp256k1_ecdh`.
+        /// Computes a compressed-format ECDH shared secret with `publicKeyShare` via
+        /// `secp256k1_ecdh`.
+        ///
+        /// Convenience wrapper that delegates to ``sharedSecretFromKeyAgreement(with:format:)``
+        /// with `.compressed` as the serialization format, matching the
+        /// `DiffieHellmanKeyAgreement` protocol signature.
         ///
         /// - Parameter publicKeyShare: The peer's public key.
         /// - Returns: A ``SharedSecret`` in compressed (33-byte) format.
@@ -185,15 +352,24 @@ public import Foundation
             sharedSecretFromKeyAgreement(with: publicKeyShare, format: .compressed)
         }
 
-        /// Computes an ECDH shared secret by calling `secp256k1_ecdh` with a custom hash closure that serializes the shared point.
+        /// Computes an ECDH shared secret by calling `secp256k1_ecdh` with a custom hash
+        /// closure that serializes the shared point.
         ///
-        /// The shared point is serialized as a compressed (33-byte) or uncompressed (65-byte) public
-        /// key depending on `format`. **Context randomization does not protect this operation
-        /// against side-channel attacks** — ECDH uses a different kind of point multiplication than
-        /// signing operations.
+        /// The shared point is serialized as a compressed (33-byte) or uncompressed
+        /// (65-byte) public key depending on `format`. This overrides the upstream default
+        /// (`secp256k1_ecdh_hash_function_sha256`, which would return a 32-byte SHA-256
+        /// hash of the compressed point) so callers receive the raw serialized EC point,
+        /// suitable as input to any higher-level KDF.
+        ///
+        /// > Important: **Context randomization does not protect this operation against
+        /// > side-channel attacks.** Per upstream `secp256k1_context_randomize`
+        /// > documentation, ECDH uses variable-point multiplication rather than base-point
+        /// > multiplication, and is explicitly excluded from the protection that
+        /// > randomization provides to ECDSA / Schnorr signing.
         ///
         /// - Parameter publicKeyShare: The peer's secp256k1 public key.
-        /// - Parameter format: Whether to serialize the shared point as compressed (33 bytes, default) or uncompressed (65 bytes).
+        /// - Parameter format: Whether to serialize the shared point as compressed
+        ///   (33 bytes, default) or uncompressed (65 bytes).
         /// - Returns: A ``SharedSecret`` containing the serialized shared point.
         public func sharedSecretFromKeyAgreement(
             with publicKeyShare: P256K.KeyAgreement.PublicKey,
@@ -211,9 +387,20 @@ public import Foundation
             return SharedSecret(ss: SecureBytes(bytes: sharedSecret), format: format)
         }
 
-        /// Returns a `secp256k1_ecdh` hash function closure that serializes the shared EC point as a compressed or uncompressed public key, bypassing the default SHA-256 hashing.
+        /// Returns a `secp256k1_ecdh` hash function closure that serializes the shared EC
+        /// point as a compressed or uncompressed public key, bypassing the default SHA-256
+        /// hashing.
         ///
-        /// - Returns: A C-compatible ``HashFunctionType`` closure for use as the `hashfp` argument of `secp256k1_ecdh`.
+        /// The returned closure reads a `Bool` from the `data` pointer (set by
+        /// ``sharedSecretFromKeyAgreement(with:format:)`` based on the requested `format`)
+        /// and writes either the 33-byte compressed encoding (`0x02`/`0x03` prefix + X) or
+        /// the 65-byte uncompressed encoding (`0x04` prefix + X + Y). Construction of the
+        /// prefix byte follows the SEC1 convention: for compressed encoding, the low bit
+        /// of the Y coordinate determines whether to prefix with `0x02` (even Y) or
+        /// `0x03` (odd Y).
+        ///
+        /// - Returns: A C-compatible ``HashFunctionType`` closure for use as the `hashfp`
+        ///   argument of `secp256k1_ecdh`.
         func hashClosure() -> HashFunctionType {
             { output, x32, y32, data in
                 guard let output, let x32, let y32, let compressed = data?.load(as: Bool.self) else { return 0 }

--- a/Sources/Shared/ECDSA/ECDSA+PrivateKey.swift
+++ b/Sources/Shared/ECDSA/ECDSA+PrivateKey.swift
@@ -18,48 +18,102 @@ public import Foundation
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K.Signing {
-    /// secp256k1 ECDSA private key for deterministically signing messages and producing ``ECDSASignature`` values using the secp256k1 curve.
+    /// secp256k1 ECDSA private key for deterministically signing messages and producing
+    /// ``ECDSASignature`` values using the secp256k1 curve.
     ///
-    /// Create a key by generating fresh randomness or by deserializing an existing raw, PEM, or DER
-    /// representation. The 32-byte secret scalar must pass `secp256k1_ec_seckey_verify` to be
-    /// accepted. Keep `dataRepresentation` confidential; exposing it compromises all signatures
-    /// produced by this key.
+    /// ## Overview
     ///
-    /// The `format` parameter controls whether the **public** key companion is serialized as
-    /// compressed (33 bytes, default) or uncompressed (65 bytes). The private key itself is always
-    /// 32 bytes regardless of format.
+    /// Create a key by generating fresh randomness or by deserializing an existing raw,
+    /// PEM, or DER representation. The 32-byte secret scalar must pass
+    /// `secp256k1_ec_seckey_verify` (declared in
+    /// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h))
+    /// to be accepted. Keep ``dataRepresentation`` confidential; exposing it compromises
+    /// all signatures produced by this key.
     ///
-    /// ## Signing
+    /// The `format` parameter controls whether the **public** key companion is serialized
+    /// as compressed (33 bytes, default) or uncompressed (65 bytes). The private key itself
+    /// is always 32 bytes regardless of format.
     ///
-    /// ECDSA signing uses `secp256k1_ecdsa_sign` with RFC 6979 deterministic nonce generation.
-    /// All signatures produced by this key are automatically normalized to lower-S form, which is
-    /// the only form accepted by `secp256k1_ecdsa_verify`. Pass a `Digest` or raw `Data` to
-    /// ``signature(for:)-2bdso``; the data overload hashes with SHA-256 before signing.
+    /// ### Signing
+    ///
+    /// ECDSA signing uses `secp256k1_ecdsa_sign` with
+    /// [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979) deterministic nonce
+    /// generation. All signatures produced by this key are automatically normalized to
+    /// lower-S form per
+    /// [BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki), which is
+    /// the only form accepted by `secp256k1_ecdsa_verify`. Pass a `Digest` or raw `Data`
+    /// to the `signature(for:)` overloads on this type; the data overload hashes with
+    /// SHA-256 before signing.
+    ///
+    /// ## Topics
+    ///
+    /// ### Construction
+    /// - ``init(format:)``
+    /// - ``init(dataRepresentation:format:)``
+    /// - ``init(pemRepresentation:)``
+    /// - ``init(derRepresentation:)``
+    ///
+    /// ### Inspection
+    /// - ``publicKey``
+    /// - ``dataRepresentation``
+    /// - ``negation``
     struct PrivateKey: Equatable, Sendable {
-        /// The internal backing key implementation.
+        /// The internal `PrivateKeyImplementation` backing this signing key.
+        ///
+        /// Kept `private` — the backing type wraps the 32-byte secret scalar in
+        /// `SecureBytes`-style zeroizing storage; consumers interact only through the
+        /// public API surface.
         private let baseKey: PrivateKeyImplementation
 
         /// The raw 32-byte secret key bytes as `SecureBytes`.
+        ///
+        /// Internal-visibility accessor used by Swift-side helpers that participate in the
+        /// `SecureBytes` lifetime (e.g. nonce-derivation helpers, `Equatable` comparison).
+        /// External callers use ``dataRepresentation`` for a `Data` copy.
         var key: SecureBytes {
             baseKey.key
         }
 
-        /// The secp256k1 public key derived from this private key, used to verify signatures this key produces.
+        /// The secp256k1 public key derived from this private key, used to verify
+        /// signatures this key produces.
+        ///
+        /// Computed on every access via `secp256k1_ec_pubkey_create`. For high-frequency
+        /// signing loops, cache the value locally rather than re-deriving it per call.
+        /// The returned public key carries the private key's ``P256K/Format`` selection.
         public var publicKey: PublicKey {
             PublicKey(baseKey: baseKey.publicKey)
         }
 
-        /// The raw 32-byte secret key as `Data`. Keep this value confidential; disclosure allows anyone to sign on your behalf.
+        /// The raw 32-byte secret key as `Data`. Keep this value confidential; disclosure
+        /// allows anyone to sign on your behalf.
+        ///
+        /// The bytes are zeroed when the backing `PrivateKeyImplementation` is
+        /// deallocated, but **copies made through this accessor are not**: any `Data`
+        /// produced here escapes the zeroization scope and must be handled by the caller.
+        /// Prefer restricting its reach to the minimum necessary scope (e.g. one encrypted
+        /// write to a keychain) before discarding.
         public var dataRepresentation: Data {
             baseKey.dataRepresentation
         }
 
-        /// A new ``PrivateKey`` whose secret scalar is the additive inverse of this key modulo the secp256k1 curve order, produced by `secp256k1_ec_seckey_negate`.
+        /// A new ``PrivateKey`` whose secret scalar is the additive inverse of this key
+        /// modulo the secp256k1 curve order, produced by `secp256k1_ec_seckey_negate`.
+        ///
+        /// Useful for BIP-32-style derivation schemes that need the negated scalar for
+        /// subtraction under addition. The result satisfies `self.key + negation.key ≡ 0
+        /// (mod n)`, equivalently `publicKey + negation.publicKey` is the point at
+        /// infinity.
         public var negation: Self {
             Self(baseKey: baseKey.negation)
         }
 
         /// Creates a private key from a validated backing implementation.
+        ///
+        /// Internal-visibility constructor used when the backing implementation has
+        /// already been validated (e.g. by ``negation`` or by the backing type's own
+        /// factory methods); consumers use the public initializers below instead.
+        ///
+        /// - Parameter baseKey: A validated `PrivateKeyImplementation`.
         init(baseKey: PrivateKeyImplementation) {
             self.baseKey = baseKey
         }

--- a/Sources/Shared/ECDSA/ECDSA+PublicKey.swift
+++ b/Sources/Shared/ECDSA/ECDSA+PublicKey.swift
@@ -18,46 +18,107 @@ public import Foundation
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K.Signing {
-    /// secp256k1 ECDSA public key for verifying ``ECDSASignature`` values, available in compressed (33-byte) or uncompressed (65-byte) serialized form.
+    /// secp256k1 ECDSA public key for verifying ``ECDSASignature`` values, available in
+    /// compressed (33-byte) or uncompressed (65-byte) serialized form.
     ///
-    /// Obtain a public key from its companion ``PrivateKey/publicKey`` property, or by deserializing
-    /// a compressed (33-byte), uncompressed (65-byte), PEM, DER, or ANSI X9.63 representation.
-    /// The serialization format is preserved and reported by the ``format`` property.
+    /// ## Overview
+    ///
+    /// Obtain a public key from its companion ``PrivateKey/publicKey`` property, or by
+    /// deserializing a compressed (33-byte), uncompressed (65-byte), PEM, DER, or ANSI
+    /// X9.63 representation. The serialization format is preserved and reported by the
+    /// ``format`` property. Parsing goes through `secp256k1_ec_pubkey_parse` (declared in
+    /// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h)),
+    /// which rejects off-curve points and wrong-length encodings.
+    ///
+    /// ## Topics
+    ///
+    /// ### Construction
+    /// - ``init(dataRepresentation:format:)``
+    /// - ``init(xonlyKey:)``
+    /// - ``init(pemRepresentation:)``
+    /// - ``init(derRepresentation:)``
+    /// - ``init(x963Representation:)``
+    ///
+    /// ### Serialized Forms
+    /// - ``dataRepresentation``
+    /// - ``uncompressedRepresentation``
+    /// - ``format``
+    /// - ``xonly``
+    ///
+    /// ### Algebra
+    /// - ``negation``
     struct PublicKey: Sendable {
-        /// The internal backing public key implementation.
+        /// The internal `PublicKeyImplementation` backing this verifying key.
+        ///
+        /// Kept `internal` — the backing type wraps the 64-byte upstream `secp256k1_pubkey`
+        /// struct plus the serialization format; consumers never see the raw C handle
+        /// through the public API.
         let baseKey: PublicKeyImplementation
 
         /// The serialized public key bytes in the key's ``format``.
+        ///
+        /// Internal-visibility accessor used by Swift-side verify helpers that want to
+        /// avoid the `Data` allocation; external callers use ``dataRepresentation`` for
+        /// the `Data` form.
         var bytes: [UInt8] {
             baseKey.bytes
         }
 
         /// The serialized public key bytes as `Data`, in the key's ``format``.
+        ///
+        /// Suitable for transmission and persistence. Produced via
+        /// `secp256k1_ec_pubkey_serialize` with the flag corresponding to the stored
+        /// ``format`` (see ``P256K/Format/rawValue``).
         public var dataRepresentation: Data {
             baseKey.dataRepresentation
         }
 
-        /// The 32-byte x-only public key (X coordinate only) derived from this key for use with Schnorr signature verification.
+        /// The 32-byte x-only public key (X coordinate only) derived from this key for use
+        /// with Schnorr signature verification.
+        ///
+        /// Computed on every access via `secp256k1_xonly_pubkey_from_pubkey`. Useful when a
+        /// workflow needs to pivot from ECDSA-era verification to Taproot-era BIP-340
+        /// verification against the same underlying public point.
         public var xonly: XonlyKey {
             XonlyKey(baseKey: baseKey.xonly)
         }
 
-        /// The serialization format of this public key: `.compressed` (33 bytes) or `.uncompressed` (65 bytes).
+        /// The serialization format of this public key: `.compressed` (33 bytes) or
+        /// `.uncompressed` (65 bytes).
+        ///
+        /// Inherited from the `format:` argument at construction time. See
+        /// ``P256K/Format`` for the SEC1 encoding details and upstream `#define` mapping.
         public var format: P256K.Format {
             baseKey.format
         }
 
-        /// A new ``PublicKey`` that is the additive inverse of this key on the secp256k1 curve, produced by `secp256k1_ec_pubkey_negate`.
+        /// A new ``PublicKey`` that is the additive inverse of this key on the secp256k1
+        /// curve, produced by `secp256k1_ec_pubkey_negate`.
+        ///
+        /// The inverse is the point `-P = (x, -y mod p)`: same X coordinate, flipped Y
+        /// parity. Satisfies `self + negation` is the point at infinity. Used in BIP-32
+        /// derivation schemes and in manual verification of aggregation properties.
         public var negation: Self {
             Self(baseKey: baseKey.negation)
         }
 
-        /// The 65-byte uncompressed serialization of this public key (0x04 prefix + 32-byte X + 32-byte Y), regardless of the key's stored ``format``.
+        /// The 65-byte uncompressed serialization of this public key (`0x04` prefix +
+        /// 32-byte X + 32-byte Y), regardless of the key's stored ``format``.
+        ///
+        /// Always returns the uncompressed SEC1 form via
+        /// `secp256k1_ec_pubkey_serialize` with `SECP256K1_EC_UNCOMPRESSED`. Useful when
+        /// interoperating with systems that require the full `(x, y)` point encoding.
         public var uncompressedRepresentation: Data {
             baseKey.uncompressedRepresentation
         }
 
         /// Creates a public key from a validated backing implementation.
+        ///
+        /// Internal-visibility constructor used by factory methods that have already
+        /// validated the backing implementation (e.g. ``negation``,
+        /// ``PrivateKey/publicKey``); consumers use the public initializers below.
+        ///
+        /// - Parameter baseKey: A validated `PublicKeyImplementation`.
         init(baseKey: PublicKeyImplementation) {
             self.baseKey = baseKey
         }

--- a/Sources/Shared/ECDSA/ECDSA+Signature.swift
+++ b/Sources/Shared/ECDSA/ECDSA+Signature.swift
@@ -20,21 +20,41 @@ public import Foundation
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K.Signing {
-    /// 64-byte secp256k1 ECDSA signature in libsecp256k1 internal format, convertible to and from DER (variable-length, up to 72 bytes) and compact (exactly 64 bytes) representations.
+    /// 64-byte secp256k1 ECDSA signature in libsecp256k1 internal format, convertible to and
+    /// from DER (variable-length, up to 72 bytes) and compact (exactly 64 bytes)
+    /// representations.
     ///
-    /// All signatures produced by ``PrivateKey/signature(for:)-2bdso`` are automatically normalized
-    /// to lower-S form by `secp256k1_ecdsa_sign`. This normalization is required because
-    /// `secp256k1_ecdsa_verify` only accepts lower-S signatures; a non-normalized signature will
-    /// always fail verification.
+    /// ## Overview
     ///
-    /// ## Serialization
+    /// All signatures produced by the `signature(for:)` overloads on ``PrivateKey`` are
+    /// automatically normalized to lower-S form by `secp256k1_ecdsa_sign` per
+    /// [BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki). This
+    /// normalization is required because `secp256k1_ecdsa_verify` only accepts lower-S
+    /// signatures; a non-normalized signature will always fail verification.
     ///
-    /// - ``compactRepresentation``: 64 bytes, `r || s` in big-endian. Use for Bitcoin witness
-    ///   fields and Nostr events.
-    /// - ``derRepresentation``: Variable-length DER encoding (up to 72 bytes). Use for
-    ///   Bitcoin legacy script and standard X.509 / TLS contexts.
+    /// The internal 64-byte `data` buffer is the opaque `secp256k1_ecdsa_signature` struct
+    /// body declared in
+    /// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h).
+    /// Its byte layout is **not** a stable wire format across libsecp256k1 versions — use
+    /// ``compactRepresentation`` or ``derRepresentation`` for persistence / transmission.
+    ///
+    /// ## Topics
+    ///
+    /// ### Construction
+    /// - ``init(dataRepresentation:)``
+    /// - ``init(compactRepresentation:)``
+    /// - ``init(derRepresentation:)``
+    ///
+    /// ### Serialized Forms
+    /// - ``compactRepresentation``
+    /// - ``derRepresentation``
     struct ECDSASignature: ContiguousBytes, NISTECDSASignature, CompactSignature {
-        /// The 64-byte libsecp256k1 internal representation of the signature (`r || s` in big-endian).
+        /// The 64-byte opaque `secp256k1_ecdsa_signature` struct buffer.
+        ///
+        /// The internal layout is not a stable wire format — use ``compactRepresentation``
+        /// or ``derRepresentation`` for cross-process persistence. The bytes here are
+        /// retained across Swift-layer operations to avoid repeat parsing; the upstream
+        /// struct stores the `(r, s)` pair in a version-specific packed form.
         public var dataRepresentation: Data
 
         /// Creates an ``ECDSASignature`` from a 64-byte raw representation.
@@ -106,7 +126,12 @@ public extension P256K.Signing {
             try dataRepresentation.withUnsafeBytes(body)
         }
 
-        /// The 64-byte compact representation of the signature (`r || s` in big-endian), produced by `secp256k1_ecdsa_signature_serialize_compact`.
+        /// The 64-byte compact representation of the signature (`r || s` in big-endian),
+        /// produced by `secp256k1_ecdsa_signature_serialize_compact`.
+        ///
+        /// Stable wire format suitable for Bitcoin witness fields, Nostr events, and other
+        /// contexts that expect a fixed-length signature. The two 32-byte halves are the
+        /// big-endian encodings of the `r` and `s` scalars respectively.
         public var compactRepresentation: Data {
             let context = P256K.Context.rawRepresentation
             var signature = secp256k1_ecdsa_signature()
@@ -125,7 +150,13 @@ public extension P256K.Signing {
             return Data(bytes: &compactSignature, count: P256K.ByteLength.signature)
         }
 
-        /// The variable-length DER-encoded representation of the signature (up to 72 bytes), produced by `secp256k1_ecdsa_signature_serialize_der`.
+        /// The variable-length DER-encoded representation of the signature (up to 72
+        /// bytes), produced by `secp256k1_ecdsa_signature_serialize_der`.
+        ///
+        /// ASN.1 DER encoding defined by SEC1 § 4.1 — the standard wire format for ECDSA
+        /// signatures in TLS, X.509 certificates, and pre-SegWit Bitcoin script. Typical
+        /// output is 70–72 bytes; the upper bound of 72 reflects the maximum DER length
+        /// including two `INTEGER` tags and length octets.
         public var derRepresentation: Data {
             let context = P256K.Context.rawRepresentation
             var signature = secp256k1_ecdsa_signature()
@@ -155,7 +186,7 @@ extension P256K.Signing.PrivateKey: DigestSigner {
     /// Generates a lower-S normalized ECDSA signature over the secp256k1 elliptic curve using RFC 6979 deterministic nonce generation.
     ///
     /// - Parameter digest: The pre-computed message digest to sign.
-    /// - Returns: An ``ECDSASignature`` in lower-S normalized form, ready for verification by ``P256K/Signing/PublicKey/isValidSignature(_:for:)-6vcl1``.
+    /// - Returns: An ``ECDSASignature`` in lower-S normalized form, ready for verification via the `isValidSignature(_:for:)` overloads on ``P256K/Signing/PublicKey``.
     public func signature<D: Digest>(for digest: D) -> P256K.Signing.ECDSASignature {
         let context = P256K.Context.rawRepresentation
         var signature = secp256k1_ecdsa_signature()

--- a/Sources/Shared/ECDSA/ECDSA+Tweak.swift
+++ b/Sources/Shared/ECDSA/ECDSA+Tweak.swift
@@ -18,11 +18,22 @@ import Foundation
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K.Signing.PrivateKey {
-    /// Creates a new ``PrivateKey`` by computing `secret_key' = (secret_key + tweak) mod n` via `secp256k1_ec_seckey_tweak_add`, where `n` is the secp256k1 curve order.
+    /// Creates a new ``PrivateKey`` by computing `secret_key' = (secret_key + tweak) mod n`
+    /// via `secp256k1_ec_seckey_tweak_add` (declared in
+    /// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h)),
+    /// where `n` is the secp256k1 curve order.
     ///
-    /// - Parameter tweak: A 32-byte tweak scalar; must not produce a result that is zero modulo `n`.
+    /// Scalar addition on private keys pairs with public-key point addition through the
+    /// homomorphism `G × (sk + t) = pk + G × t` — the foundation of
+    /// [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) unhardened
+    /// child key derivation. For BIP-341 Taproot key-path tweaking, use
+    /// ``P256K/Schnorr/XonlyKey/add(_:)`` on the x-only form instead.
+    ///
+    /// - Parameter tweak: A 32-byte tweak scalar; must not produce a result that is zero
+    ///   modulo `n`.
     /// - Returns: A new ``PrivateKey`` with the tweaked secret scalar.
-    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the result is zero modulo `n`.
+    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the
+    ///   result is zero modulo `n`.
     func add(_ tweak: [UInt8]) throws -> Self {
         let context = P256K.Context.rawRepresentation
         var privateBytes = key.bytes
@@ -35,11 +46,17 @@ public extension P256K.Signing.PrivateKey {
         return Self(baseKey: PrivateKeyImplementation(validatedBytes: privateBytes, format: .compressed))
     }
 
-    /// Creates a new ``PrivateKey`` by computing `secret_key' = (secret_key × tweak) mod n` via `secp256k1_ec_seckey_tweak_mul`, where `n` is the secp256k1 curve order.
+    /// Creates a new ``PrivateKey`` by computing `secret_key' = (secret_key × tweak) mod n`
+    /// via `secp256k1_ec_seckey_tweak_mul`, where `n` is the secp256k1 curve order.
+    ///
+    /// Scalar multiplication pairs with public-key point scaling through
+    /// `G × (sk × t) = pk × t`. Less common than ``add(_:)`` in Bitcoin workflows but
+    /// useful for blinding schemes and some threshold-signature constructions.
     ///
     /// - Parameter tweak: A 32-byte tweak scalar; must be non-zero and less than `n`.
     /// - Returns: A new ``PrivateKey`` with the scaled secret scalar.
-    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the result fails `secp256k1_ec_seckey_verify`.
+    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the
+    ///   result fails `secp256k1_ec_seckey_verify`.
     func multiply(_ tweak: [UInt8]) throws -> Self {
         let context = P256K.Context.rawRepresentation
         var privateBytes = key.bytes
@@ -55,12 +72,22 @@ public extension P256K.Signing.PrivateKey {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K.Signing.PublicKey {
-    /// Creates a new ``PublicKey`` by computing `public_key' = public_key + G × tweak` via `secp256k1_ec_pubkey_tweak_add`, where `G` is the secp256k1 generator point.
+    /// Creates a new ``PublicKey`` by computing `public_key' = public_key + G × tweak` via
+    /// `secp256k1_ec_pubkey_tweak_add`, where `G` is the secp256k1 generator point.
+    ///
+    /// The public-key counterpart to ``P256K/Signing/PrivateKey/add(_:)`` — applying the
+    /// same 32-byte tweak to both forms yields a valid `(sk', pk')` pair. Used by
+    /// [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) unhardened
+    /// public-key-only derivation (watch-only wallets) when the parent private key is not
+    /// available.
     ///
     /// - Parameter tweak: A 32-byte tweak scalar; must not produce the point at infinity.
-    /// - Parameter format: The serialization format of the returned ``PublicKey``; defaults to `.compressed`.
-    /// - Returns: A new ``PublicKey`` equal to the original key plus the tweak times the generator.
-    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the result is the point at infinity.
+    /// - Parameter format: The serialization format of the returned ``PublicKey``; defaults
+    ///   to `.compressed`.
+    /// - Returns: A new ``PublicKey`` equal to the original key plus the tweak times the
+    ///   generator.
+    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the
+    ///   result is the point at infinity.
     func add(_ tweak: [UInt8], format: P256K.Format = .compressed) throws -> Self {
         let context = P256K.Context.rawRepresentation
         var pubKey = baseKey.rawRepresentation
@@ -75,12 +102,19 @@ public extension P256K.Signing.PublicKey {
         return Self(baseKey: PublicKeyImplementation(validatedBytes: pubKeyBytes, format: format))
     }
 
-    /// Creates a new ``PublicKey`` by computing `public_key' = public_key × tweak` via `secp256k1_ec_pubkey_tweak_mul`.
+    /// Creates a new ``PublicKey`` by computing `public_key' = public_key × tweak` via
+    /// `secp256k1_ec_pubkey_tweak_mul`.
+    ///
+    /// The public-key counterpart to ``P256K/Signing/PrivateKey/multiply(_:)``; applying
+    /// the same tweak to both forms yields a valid `(sk', pk')` pair.
     ///
     /// - Parameter tweak: A 32-byte tweak scalar; must be non-zero.
-    /// - Parameter format: The serialization format of the returned ``PublicKey``; defaults to `.compressed`.
-    /// - Returns: A new ``PublicKey`` equal to the original key multiplied by the tweak scalar.
-    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the result is the point at infinity.
+    /// - Parameter format: The serialization format of the returned ``PublicKey``; defaults
+    ///   to `.compressed`.
+    /// - Returns: A new ``PublicKey`` equal to the original key multiplied by the tweak
+    ///   scalar.
+    /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or the
+    ///   result is the point at infinity.
     func multiply(_ tweak: [UInt8], format: P256K.Format = .compressed) throws -> Self {
         let context = P256K.Context.rawRepresentation
         var pubKey = baseKey.rawRepresentation

--- a/Sources/Shared/ECDSA/ECDSA+XonlyKey.swift
+++ b/Sources/Shared/ECDSA/ECDSA+XonlyKey.swift
@@ -18,30 +18,69 @@ public import Foundation
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K.Signing {
-    /// The 32-byte x-only form of a secp256k1 ``P256K/Signing/PublicKey``, as defined by BIP-340: the X coordinate of the public key point with implicit even-Y parity unless ``parity`` is `true`.
+    /// The 32-byte x-only form of a secp256k1 ``P256K/Signing/PublicKey``, as defined by
+    /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki): the X
+    /// coordinate of the public key point with implicit even-Y parity unless ``parity`` is
+    /// `true`.
+    ///
+    /// Conversion uses `secp256k1_xonly_pubkey_from_pubkey` (declared in
+    /// [`Vendor/secp256k1/include/secp256k1_extrakeys.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_extrakeys.h)),
+    /// which flips the sign of the point when its Y coordinate is odd and records the
+    /// original parity so callers can reconstruct the full point later. Useful when pivoting
+    /// from ECDSA-era verification into BIP-340 / Taproot workflows without regenerating the
+    /// key material.
+    ///
+    /// ## Topics
+    ///
+    /// ### Inspection
+    /// - ``bytes``
+    /// - ``parity``
+    ///
+    /// ### Construction
+    /// - ``init(dataRepresentation:keyParity:)``
     struct XonlyKey: Sendable {
-        /// The internal backing x-only key implementation.
+        /// The internal `XonlyKeyImplementation` backing this x-only key.
+        ///
+        /// Kept `private` — the backing type is an internal convenience over the upstream
+        /// `secp256k1_xonly_pubkey` struct; consumers never see or manipulate it directly.
         private let baseKey: XonlyKeyImplementation
 
         /// The 32-byte X coordinate of this x-only public key.
+        ///
+        /// Stable across libsecp256k1 versions — safe to persist as a BIP-340-style key
+        /// identifier. Pair with ``parity`` if the full `(x, y)` point must be reconstructed
+        /// downstream (e.g. for tweak verification).
         public var bytes: [UInt8] {
             baseKey.bytes
         }
 
-        /// The Y-coordinate parity of the underlying secp256k1 public key, as returned by `secp256k1_xonly_pubkey_from_pubkey`.
+        /// The Y-coordinate parity of the underlying secp256k1 public key, as returned by
+        /// `secp256k1_xonly_pubkey_from_pubkey`.
         ///
-        /// `false` means the Y coordinate is even (the canonical BIP-340 form); `true` means it is odd
-        /// (the public key point is the negation of the even-Y point with the same X coordinate).
+        /// `false` means the Y coordinate is even (the canonical BIP-340 form); `true`
+        /// means it is odd (the public key point is the negation of the even-Y point with
+        /// the same X coordinate). BIP-340 verifiers operate against the even-Y
+        /// representative, so the parity bit is tracked separately and consulted during
+        /// Taproot tweak verification.
         public var parity: Bool {
             baseKey.keyParity.boolValue
         }
 
         /// Creates a ``XonlyKey`` from a validated backing implementation.
+        ///
+        /// Internal-visibility constructor used by ``P256K/Signing/PublicKey/xonly``;
+        /// consumers access x-only keys through that accessor or via the public
+        /// initializer below.
+        ///
+        /// - Parameter baseKey: A validated `XonlyKeyImplementation`.
         init(baseKey: XonlyKeyImplementation) {
             self.baseKey = baseKey
         }
 
         /// Creates a ``XonlyKey`` from a 32-byte X-coordinate and its Y-coordinate parity.
+        ///
+        /// Useful when reconstructing an x-only key from a persisted `(bytes, parity)` pair
+        /// (e.g. a Taproot output-key identifier stored in a wallet database).
         ///
         /// - Parameter data: The 32-byte X coordinate of the x-only public key.
         /// - Parameter keyParity: The Y-coordinate parity as `Int32`: `0` = even, `1` = odd.

--- a/Sources/Shared/ECDSA/ECDSA.swift
+++ b/Sources/Shared/ECDSA/ECDSA.swift
@@ -16,18 +16,27 @@ import Foundation
     import libsecp256k1
 #endif
 
+/// Composition constraint matching swift-crypto's NIST-curve ECDSA signature shape: any
+/// type that exposes both a compact `dataRepresentation` and a DER `derRepresentation`.
 typealias NISTECDSASignature = DERSignature & DataSignature
 
+/// Internal-visibility protocol used by signature types to surface a fixed-width
+/// serialization (64 bytes for ECDSA compact).
 protocol DataSignature {
     init<D: DataProtocol>(dataRepresentation: D) throws
     var dataRepresentation: Data { get }
 }
 
+/// Internal-visibility protocol used by signature types to surface the ASN.1 DER
+/// serialization defined by SEC1 § 4.1. DER-encoded ECDSA signatures are variable-length
+/// (roughly 70–72 bytes in practice).
 protocol DERSignature {
     init<D: DataProtocol>(derRepresentation: D) throws
     var derRepresentation: Data { get }
 }
 
+/// Internal-visibility protocol used by signature types to surface a Bitcoin-style
+/// compact serialization (64 bytes for ECDSA, 65 bytes for recoverable ECDSA).
 protocol CompactSignature {
     init<D: DataProtocol>(compactRepresentation: D) throws
     var compactRepresentation: Data { get }
@@ -35,12 +44,41 @@ protocol CompactSignature {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K {
-    /// secp256k1 ECDSA signing namespace providing ``PrivateKey`` for RFC 6979 deterministic signing and ``PublicKey`` for signature verification; all produced signatures are lower-S normalized.
+    /// secp256k1 ECDSA signing namespace providing ``PrivateKey`` for RFC 6979 deterministic
+    /// signing and ``PublicKey`` for signature verification; all produced signatures are
+    /// lower-S normalized.
     ///
-    /// ECDSA (Elliptic Curve Digital Signature Algorithm) is the signature scheme used in Bitcoin
-    /// transactions and compatible with a wide range of cryptographic infrastructure. Use
-    /// ``Signing/PrivateKey`` to sign and ``Signing/PublicKey`` to verify. Both accept `Digest`
-    /// inputs for pre-hashed messages and `DataProtocol` inputs that are hashed with SHA-256
-    /// internally before the operation.
+    /// ## Overview
+    ///
+    /// ECDSA (Elliptic Curve Digital Signature Algorithm) is the legacy signature scheme used
+    /// in Bitcoin transactions (pre-Taproot) and throughout the wider cryptographic
+    /// ecosystem. Use ``Signing/PrivateKey`` to sign and ``Signing/PublicKey`` to verify. Both
+    /// accept `Digest` inputs for pre-hashed messages and `DataProtocol` inputs that are
+    /// hashed with SHA-256 internally before the operation.
+    ///
+    /// Signatures are produced via `secp256k1_ecdsa_sign` with
+    /// [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979) deterministic nonce
+    /// generation and verified via `secp256k1_ecdsa_verify` (both declared in
+    /// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h)).
+    /// Taproot-era signing uses ``P256K/Schnorr`` instead.
+    ///
+    /// ### Lower-S Normalization
+    ///
+    /// ECDSA signatures have a mathematical symmetry: `(r, s)` and `(r, -s mod n)` both
+    /// verify against the same message/key pair. Bitcoin's
+    /// [BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki) requires
+    /// transactions to use the "low-S" form (where `s < n/2`) to prevent signature
+    /// malleability. All signatures produced by this library are automatically normalized
+    /// to lower-S; `secp256k1_ecdsa_verify` likewise only accepts lower-S signatures.
+    ///
+    /// ## Topics
+    ///
+    /// ### Key Types
+    /// - ``PrivateKey``
+    /// - ``PublicKey``
+    /// - ``XonlyKey``
+    ///
+    /// ### Signature Types
+    /// - ``ECDSASignature``
     enum Signing: Sendable {}
 }

--- a/Sources/Shared/Errors.swift
+++ b/Sources/Shared/Errors.swift
@@ -8,14 +8,45 @@
 //  See the accompanying file LICENSE for information
 //
 
-/// Errors thrown by swift-secp256k1 operations: covers key-size mismatches, byte-count errors for individual parameters, and failures propagated from the libsecp256k1 C library.
+/// Errors thrown by swift-secp256k1 operations: covers key-size mismatches, byte-count errors
+/// for individual parameters, and failures propagated from the upstream libsecp256k1 C library
+/// (see [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h)).
+///
+/// ## Topics
+///
+/// ### Size Validation
+/// - ``incorrectKeySize``
+/// - ``incorrectParameterSize``
+///
+/// ### Upstream Failures
+/// - ``underlyingCryptoError``
 public enum secp256k1Error: Error {
-    /// A key was deserialized with the wrong byte count (e.g., 33 bytes for compressed or 65 bytes for uncompressed secp256k1 keys).
+    /// A key was deserialized with the wrong byte count.
+    ///
+    /// Thrown when a serialized secp256k1 key's length does not match the expected
+    /// ``P256K/Format``: 32 bytes for a private key, 33 bytes for ``P256K/Format/compressed``
+    /// or x-only public keys, or 65 bytes for ``P256K/Format/uncompressed`` public keys.
+    /// The validation happens **before** any upstream C call, so this case surfaces
+    /// ill-formed inputs at the Swift layer.
     case incorrectKeySize
 
-    /// A function argument had the wrong number of bytes (e.g., a 32-byte hash, nonce, or tweak scalar was expected but not provided).
+    /// A function argument had the wrong number of bytes.
+    ///
+    /// Thrown when a non-key parameter fails its fixed-length check — most commonly a
+    /// 32-byte message digest, tweak scalar, nonce seed, or auxiliary randomness buffer.
+    /// Distinct from ``incorrectKeySize`` so consumers can differentiate key-validation
+    /// failures from argument-validation failures.
     case incorrectParameterSize
 
-    /// A libsecp256k1 C function returned `0`, indicating the cryptographic operation failed (invalid key, invalid signature, or arithmetic failure).
+    /// A libsecp256k1 C function returned `0`, indicating the cryptographic operation
+    /// failed.
+    ///
+    /// The upstream C API convention is that all boolean-returning functions return `1`
+    /// on success and `0` on failure. This case wraps every such failure uniformly without
+    /// attempting to recover the specific reason (the upstream API is deliberately opaque
+    /// about failure modes to avoid leaking secret-dependent information through the
+    /// error channel). Common triggers: invalid private key scalar (zero or ≥ curve
+    /// order), invalid signature encoding, off-curve public-key points, invalid Taproot
+    /// tweak, or a fatal internal-consistency check.
     case underlyingCryptoError
 }

--- a/Sources/Shared/HashDigest.swift
+++ b/Sources/Shared/HashDigest.swift
@@ -37,7 +37,7 @@ import Foundation
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public typealias SHA256Digest = HashDigest
 
-/// 32-byte SHA-256 digest conforming to `Digest` so it can be passed directly to secp256k1 signing and verification APIs such as ``P256K/Signing/PrivateKey/signature(for:)-2rpq9`` and ``P256K/Schnorr/PrivateKey/signature(for:)``.
+/// 32-byte SHA-256 digest conforming to `Digest` so it can be passed directly to secp256k1 signing and verification APIs (the `signature(for:)` overloads on ``P256K/Signing/PrivateKey`` and ``P256K/Schnorr/PrivateKey`` that take a `Digest`).
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public struct HashDigest: Digest {
     let bytes: (UInt64, UInt64, UInt64, UInt64)

--- a/Sources/Shared/Keys/P256K.swift
+++ b/Sources/Shared/Keys/P256K.swift
@@ -23,46 +23,105 @@
     import libsecp256k1
 #endif
 
-/// secp256k1 elliptic curve namespace providing ECDSA signing, Schnorr signatures (BIP-340), MuSig2 multi-signatures, ECDH key agreement, and key recovery.
+/// secp256k1 elliptic curve namespace providing ECDSA signing, Schnorr signatures
+/// ([BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)),
+/// MuSig2 multi-signatures, ECDH key agreement, and key recovery.
+///
+/// ## Overview
 ///
 /// `P256K` is the top-level Swift namespace for cryptographic operations on the secp256k1 elliptic
-/// curve, which is used in Bitcoin, Lightning Network, and Nostr. Every operation requires a
-/// secp256k1 context managed by ``P256K/Context``. The library provides a shared, pre-randomized
-/// instance via ``P256K/Context/rawRepresentation`` that is suitable for all standard operations.
+/// curve, which is used in Bitcoin, Lightning Network, and Nostr. The namespace enum itself holds
+/// no state; it exists to group cryptographic sub-types (``Signing``, ``Schnorr``, ``MuSig``,
+/// ``KeyAgreement``, ``Recovery``) under a single import-friendly prefix that matches the curve
+/// name used throughout the Bitcoin ecosystem.
 ///
-/// ## Submodules
+/// Every operation requires a secp256k1 context managed by ``P256K/Context``. The library provides
+/// a shared, pre-randomized instance via ``P256K/Context/rawRepresentation`` that is suitable for
+/// all standard operations; applications do not need to create or manage contexts directly unless
+/// they have unusual side-channel or multi-threading requirements.
 ///
-/// - ``P256K/Signing``: ECDSA signing and verification. Signatures are normalized to lower-S form,
-///   the only form accepted by `secp256k1_ecdsa_verify`.
-/// - ``P256K/Schnorr``: BIP-340 Schnorr signatures. Verification uses 32-byte x-only public keys
-///   that encode only the X coordinate of the public key point.
-/// - ``P256K/MuSig``: BIP-327 MuSig2 multi-signatures. Multiple independent signers produce a
-///   single Schnorr signature over an aggregated public key without a trusted dealer.
-/// - ``P256K/KeyAgreement``: ECDH key agreement via `secp256k1_ecdh`. Context randomization does
-///   **not** provide side-channel protection for ECDH; it uses a different kind of point
-///   multiplication than ECDSA or Schnorr signing.
-/// - ``P256K/Recovery``: ECDSA recoverable signatures. A recovered public key is a candidate key
-///   consistent with the signature and message digest — it is not proof that the signature is valid.
-/// - ``P256K/Context``: Context lifecycle and side-channel protection. Use
-///   ``P256K/Context/rawRepresentation`` for all standard operations.
+/// ### Side-Channel Protection
+///
+/// Context randomization seeds a blinding factor applied to base-point multiplications during
+/// ECDSA / Schnorr signing and public-key derivation, mitigating timing and power-analysis
+/// attacks. ECDH (``KeyAgreement``) uses a different primitive (variable-point multiplication)
+/// and does **not** benefit from context blinding — consumers needing side-channel-hardened
+/// ECDH should perform it on an air-gapped device or with platform-specific mitigations.
+///
+/// ### Concurrency
+///
+/// `P256K` conforms to `Sendable`. The shared context is thread-safe for all const-qualified
+/// upstream functions, which covers every public API in this library. No locking is required.
+///
+/// ## Topics
+///
+/// ### Sub-Namespaces
+///
+/// - ``P256K/Signing``
+/// - ``P256K/Schnorr``
+/// - ``P256K/MuSig``
+/// - ``P256K/KeyAgreement``
+/// - ``P256K/Recovery``
+/// - ``P256K/Context``
+///
+/// ### Serialization
+///
+/// - ``P256K/Format``
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public enum P256K: Sendable {}
 
 /// Serialization format selection for secp256k1 public key operations.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension P256K {
-    /// Compressed (33-byte) and uncompressed (65-byte) serialization formats for secp256k1 public keys, passed as flags to `secp256k1_ec_pubkey_serialize`.
+    /// Compressed (33-byte) and uncompressed (65-byte) serialization formats for secp256k1
+    /// public keys, passed as flags to `secp256k1_ec_pubkey_serialize`.
     ///
-    /// Use `.compressed` for standard secp256k1 key storage and transmission in Bitcoin and Nostr
-    /// contexts. Use `.uncompressed` when interoperating with systems that require the full curve
-    /// point, including both X and Y coordinates.
+    /// ## Overview
+    ///
+    /// Use ``compressed`` for standard secp256k1 key storage and transmission in Bitcoin and
+    /// Nostr contexts — this has been the default since Bitcoin Core 0.6 (2012) and saves
+    /// 32 bytes per key on the wire. Use ``uncompressed`` when interoperating with systems
+    /// that require the full `(x, y)` curve point, including legacy Bitcoin addresses, some
+    /// OpenSSL wire formats, and non-Bitcoin ECDSA consumers that have not adopted the
+    /// point-compression optimization.
+    ///
+    /// Schnorr / BIP-340 / Taproot workflows use a third representation (x-only, 32 bytes)
+    /// which is modeled separately via ``Schnorr/XonlyKey`` and is **not** a `Format` case.
+    ///
+    /// ## Topics
+    ///
+    /// ### Cases
+    /// - ``compressed``
+    /// - ``uncompressed``
+    ///
+    /// ### Serialization Details
+    /// - ``length``
+    /// - ``rawValue``
     enum Format: UInt32, Sendable {
-        /// 33-byte secp256k1 public key: a 1-byte parity prefix (0x02 for even Y, 0x03 for odd Y) followed by the 32-byte X coordinate.
+        /// 33-byte secp256k1 public key: a 1-byte parity prefix (`0x02` for even Y, `0x03` for
+        /// odd Y) followed by the 32-byte X coordinate.
+        ///
+        /// Default format in `P256K` and the Bitcoin ecosystem at large. Equivalent to the
+        /// upstream `SECP256K1_EC_COMPRESSED` flag (`1 << 1 | 1 << 8`). Safe for persistence
+        /// and cross-process transmission.
         case compressed
-        /// 65-byte secp256k1 public key: a 0x04 prefix byte followed by the full 32-byte X coordinate and 32-byte Y coordinate.
+
+        /// 65-byte secp256k1 public key: a `0x04` prefix byte followed by the full 32-byte X
+        /// coordinate and 32-byte Y coordinate.
+        ///
+        /// Equivalent to the upstream `SECP256K1_EC_UNCOMPRESSED` flag (`1 << 1`). Used only
+        /// when interoperating with systems that cannot (or will not) perform the Y-recovery
+        /// step required by compressed keys. Consider migrating such systems to ``compressed``
+        /// where possible — the Y coordinate can always be recovered from X and parity.
         case uncompressed
 
-        /// The serialized byte length of the public key: 33 bytes for `.compressed`, 65 bytes for `.uncompressed`.
+        /// The serialized byte length of the public key: 33 bytes for ``compressed``, 65 bytes
+        /// for ``uncompressed``.
+        ///
+        /// Pre-computed from the 32-byte curve-coordinate dimension so that buffer sizing
+        /// downstream does not depend on hard-coded magic numbers.
+        ///
+        /// - Returns: `33` for ``compressed``, `65` for ``uncompressed``.
         public var length: Int {
             switch self {
             case .compressed: return P256K.ByteLength.dimension + 1
@@ -70,7 +129,14 @@ public extension P256K {
             }
         }
 
-        /// The `secp256k1_ec_pubkey_serialize` format flag: `SECP256K1_EC_COMPRESSED` for `.compressed`, `SECP256K1_EC_UNCOMPRESSED` for `.uncompressed`.
+        /// The `secp256k1_ec_pubkey_serialize` format flag: `SECP256K1_EC_COMPRESSED` for
+        /// ``compressed``, `SECP256K1_EC_UNCOMPRESSED` for ``uncompressed``.
+        ///
+        /// Exposed as the `RawValue` of the enum so the flag can be passed directly into the
+        /// upstream C API without additional translation. The numeric values match the
+        /// upstream `#define` pattern exactly.
+        ///
+        /// - Returns: The `UInt32` flag the upstream C serialization helpers expect.
         public var rawValue: UInt32 {
             let value: Int32
 
@@ -85,35 +151,69 @@ public extension P256K {
 }
 
 /// Internal byte length constants for secp256k1 key and signature data structures.
+///
+/// These constants exist to avoid scattered `32` / `33` / `64` / `65` magic numbers through the
+/// Swift API layer and to make the upstream-C byte-layout contract self-documenting at the
+/// call site. All values are fixed by the secp256k1 curve (256-bit prime field) and the BIP-340
+/// / libsecp256k1 serialization formats; they do not depend on runtime configuration.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension P256K {
     /// Byte length constants for secp256k1 keys, coordinates, and signatures.
+    ///
+    /// Kept `@usableFromInline` so each constant can be inlined into public `@inlinable` sites
+    /// without forcing the entire namespace to be `public`.
     @usableFromInline
     enum ByteLength {
         /// Number of bytes in one coordinate dimension of the secp256k1 elliptic curve (32).
+        ///
+        /// Equal to `ceil(log2(p) / 8)` where `p` is the secp256k1 field prime
+        /// (`2^256 - 2^32 - 977`). Multiplied by 2 for uncompressed point encodings; used as
+        /// the base unit for every other length constant here.
         @inlinable
         static var dimension: Int {
             32
         }
 
         /// Number of bytes in a secp256k1 private key (32).
+        ///
+        /// A private key is a scalar in `[1, n-1]` where `n` is the curve order; 32 bytes is
+        /// sufficient to represent any valid scalar. The upstream C API refuses key bytes that
+        /// encode `0` or a value `>= n` via `secp256k1_ec_seckey_verify`.
         @inlinable
         static var privateKey: Int {
             32
         }
 
         /// Number of bytes in a secp256k1 ECDSA or Schnorr signature (64).
+        ///
+        /// Used for the compact / BIP-340 encodings. DER-encoded ECDSA signatures are
+        /// variable-length (~70 bytes typical) and are handled separately by the
+        /// ``Signing/ECDSASignature/derRepresentation`` helper.
         @inlinable
         static var signature: Int {
             64
         }
 
-        /// Number of bytes in a MuSig2 partial signature (36).
+        /// Size in bytes of the opaque `secp256k1_musig_partial_sig` in-memory struct (36).
+        ///
+        /// This is the struct size used for stack / heap allocation when holding a partial
+        /// signature in memory; see `Vendor/secp256k1-zkp/include/secp256k1_musig.h` where
+        /// `secp256k1_musig_partial_sig` is declared as `unsigned char data[36]`.
+        ///
+        /// > Important: The 36-byte struct is **opaque**; callers must not inspect or persist
+        /// > its raw bytes. The wire-format serialization of a partial signature is 32 bytes,
+        /// > produced by `secp256k1_musig_partial_sig_serialize(out32, ...)` and consumed by
+        /// > `secp256k1_musig_partial_sig_parse(..., in32)`.
         @inlinable
         static var partialSignature: Int {
             36
         }
 
+        /// Number of bytes in an uncompressed secp256k1 public key (65).
+        ///
+        /// The 1-byte `0x04` prefix plus two 32-byte coordinates. Pre-computed so the
+        /// upstream `secp256k1_ec_pubkey_serialize` buffer can be sized with a single constant
+        /// rather than the arithmetic `2 * dimension + 1`.
         @inlinable
         static var uncompressedPublicKey: Int {
             65

--- a/Sources/Shared/Keys/PrivateKeyImplementation.swift
+++ b/Sources/Shared/Keys/PrivateKeyImplementation.swift
@@ -23,27 +23,65 @@
     import libsecp256k1
 #endif
 
-/// Internal backing implementation for a secp256k1 private key, storing 32 secret bytes as `SecureBytes` alongside the derived public key, x-only key, and key parity.
+/// Internal backing implementation for a secp256k1 private key, storing 32 secret bytes
+/// as `SecureBytes` alongside the derived public key, x-only key, and key parity.
+///
+/// Kept `@usableFromInline` so it can back the public signing / Schnorr / ECDH / Recovery
+/// key types across `Sources/Shared/*` without widening the public API surface. The
+/// structure caches the public-key derivations eagerly at construction time to avoid
+/// redundant calls to `secp256k1_ec_pubkey_create` on every signing operation.
+///
+/// All upstream C symbols referenced here are declared in
+/// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h)
+/// (key creation, serialization, negation) and
+/// [`Vendor/secp256k1/include/secp256k1_extrakeys.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_extrakeys.h)
+/// (x-only public-key conversion).
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 @usableFromInline struct PrivateKeyImplementation: Sendable {
     /// The raw 32-byte secret key, stored in `SecureBytes` to prevent accidental disclosure.
+    ///
+    /// `SecureBytes` zeros its underlying buffer when deallocated, providing a
+    /// best-effort defence against secret retention in freed memory. Exposed to Swift-
+    /// layer helpers via ``key``; external callers go through ``dataRepresentation``.
     private var privateBytes: SecureBytes
 
     /// The raw 32-byte secret key as `SecureBytes`.
+    ///
+    /// Internal-visibility accessor used by Swift-layer signing helpers that participate
+    /// in the `SecureBytes` lifetime. External callers reach the bytes via
+    /// ``dataRepresentation`` (which allocates a fresh `Data` copy).
     var key: SecureBytes {
         privateBytes
     }
 
-    /// Serialized secp256k1 public key bytes derived from `privateBytes` via `secp256k1_ec_pubkey_create` and `secp256k1_ec_pubkey_serialize`.
+    /// Serialized secp256k1 public key bytes derived from `privateBytes` via
+    /// `secp256k1_ec_pubkey_create` and `secp256k1_ec_pubkey_serialize`.
+    ///
+    /// Cached once at construction so signing-heavy workloads don't pay the
+    /// derivation cost on every call. Length is ``format`` dependent: 33 bytes for
+    /// compressed, 65 for uncompressed.
     @usableFromInline let publicBytes: [UInt8]
 
-    /// Serialized x-only public key bytes (32-byte X coordinate) derived from `publicBytes` via `secp256k1_xonly_pubkey_serialize`.
+    /// Serialized x-only public key bytes (32-byte X coordinate) derived from
+    /// `publicBytes` via `secp256k1_xonly_pubkey_serialize`.
+    ///
+    /// Cached at construction so Schnorr / Taproot workflows can reach the BIP-340
+    /// representation without a re-derivation step.
     @usableFromInline let xonlyBytes: [UInt8]
 
-    /// Serialization format of `publicBytes`.
+    /// Serialization format of `publicBytes`: compressed (33 bytes) or uncompressed
+    /// (65 bytes).
+    ///
+    /// Selected at construction time; subsequent serialization helpers respect this
+    /// choice when producing `Data` copies of the companion public key.
     @usableFromInline let format: P256K.Format
 
-    /// Parity of the public key's Y coordinate: 0 if even, 1 if odd, as returned by `secp256k1_xonly_pubkey_from_pubkey`.
+    /// Parity of the public key's Y coordinate: `0` if even, `1` if odd, as returned
+    /// by `secp256k1_xonly_pubkey_from_pubkey`.
+    ///
+    /// Needed to reconstruct the full `(x, y)` point from the x-only representation
+    /// and consulted during BIP-341 Taproot tweak verification. Stored as `Int32` for
+    /// direct upstream-API interop.
     @usableFromInline var keyParity: Int32
 
     /// The public key implementation derived from this private key.

--- a/Sources/Shared/Keys/PublicKeyImplementation.swift
+++ b/Sources/Shared/Keys/PublicKeyImplementation.swift
@@ -23,22 +23,58 @@
     import libsecp256k1
 #endif
 
-/// Internal backing implementation for a validated secp256k1 public key, storing serialized bytes, the derived x-only key, key parity, and an optional MuSig2 aggregation cache.
+/// Internal backing implementation for a validated secp256k1 public key, storing
+/// serialized bytes, the derived x-only key, key parity, and an optional MuSig2
+/// aggregation cache.
+///
+/// Kept `@usableFromInline` so it can back the public signing / Schnorr / ECDH / MuSig /
+/// Recovery public-key types across `Sources/Shared/*` without widening the public API
+/// surface. All derived forms (x-only, uncompressed, parsed `secp256k1_pubkey`) are
+/// reachable through this single backing type.
+///
+/// Upstream C symbols referenced here are declared in
+/// [`Vendor/secp256k1/include/secp256k1.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h),
+/// [`Vendor/secp256k1/include/secp256k1_extrakeys.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_extrakeys.h),
+/// and (for the aggregation cache)
+/// [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h).
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 @usableFromInline struct PublicKeyImplementation: Sendable {
-    /// Serialized secp256k1 public key bytes in the key's ``P256K/Format``, as output by `secp256k1_ec_pubkey_serialize`.
+    /// Serialized secp256k1 public key bytes in the key's ``P256K/Format``, as output by
+    /// `secp256k1_ec_pubkey_serialize`.
+    ///
+    /// Length matches ``format`` (33 bytes for compressed, 65 for uncompressed). Cached
+    /// at construction so downstream operations don't re-serialize on every access.
     @usableFromInline let bytes: [UInt8]
 
-    /// Serialized x-only public key bytes (32-byte X coordinate), as output by `secp256k1_xonly_pubkey_serialize`.
+    /// Serialized x-only public key bytes (32-byte X coordinate), as output by
+    /// `secp256k1_xonly_pubkey_serialize`.
+    ///
+    /// Cached at construction so Schnorr / BIP-340 / Taproot workflows can reach the
+    /// x-only form without a re-derivation step. Pair with ``keyParity`` to reconstruct
+    /// the full `(x, y)` point.
     @usableFromInline let xonlyBytes: [UInt8]
 
-    /// Parity of the public key's Y coordinate: 0 if Y is even, 1 if Y is odd, as returned by `secp256k1_xonly_pubkey_from_pubkey`.
+    /// Parity of the public key's Y coordinate: `0` if Y is even, `1` if Y is odd, as
+    /// returned by `secp256k1_xonly_pubkey_from_pubkey`.
+    ///
+    /// Needed to reconstruct the full `(x, y)` point from the x-only representation and
+    /// consulted during BIP-341 Taproot tweak verification.
     @usableFromInline let keyParity: Int32
 
-    /// A key format representation of the backing public key
+    /// Serialization format of ``bytes``: compressed (33 bytes) or uncompressed
+    /// (65 bytes).
+    ///
+    /// Fixed at construction time; public accessors that return ``bytes`` as `Data`
+    /// respect this choice without re-serializing into the alternative form.
     @usableFromInline let format: P256K.Format
 
-    /// Serialized MuSig2 public key aggregation cache, populated when this key was created as part of an aggregate key computation. Empty for non-aggregated keys.
+    /// Serialized MuSig2 public-key aggregation cache, populated when this key was
+    /// created as part of an aggregate key computation. Empty for non-aggregated keys.
+    ///
+    /// Holds the 197-byte opaque `secp256k1_musig_keyagg_cache` struct body required to
+    /// continue signing / tweaking against this aggregate. The bytes are **not** a
+    /// stable serialization format across libsecp256k1 versions — treat as a
+    /// within-process session token.
     @usableFromInline let cache: [UInt8]
 
     /// The x-only public key derived from this public key, used for Schnorr signature verification.

--- a/Sources/Shared/Keys/XonlyKeyImplementation.swift
+++ b/Sources/Shared/Keys/XonlyKeyImplementation.swift
@@ -23,21 +23,42 @@
     import libsecp256k1
 #endif
 
-/// Internal backing implementation for a secp256k1 x-only public key (BIP-340), storing the 32-byte X coordinate, key parity, and an optional MuSig2 aggregation cache.
+/// Internal backing implementation for a secp256k1 x-only public key
+/// ([BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)), storing
+/// the 32-byte X coordinate, key parity, and an optional MuSig2 aggregation cache.
 ///
-/// An x-only public key encodes a curve point whose Y coordinate is even. It is serialized as
-/// only its 32-byte X coordinate. The `keyParity` value records whether the full public key's Y
-/// coordinate required negation to produce the even-Y form, which is needed for certain Taproot
-/// tweaking operations.
+/// ## Overview
+///
+/// An x-only public key encodes a curve point whose Y coordinate is even. It is
+/// serialized as only its 32-byte X coordinate. The `keyParity` value records whether
+/// the original full public key's Y coordinate required negation to produce the even-Y
+/// form — needed for BIP-341 Taproot tweaking operations
+/// ([`Vendor/secp256k1/include/secp256k1_extrakeys.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_extrakeys.h)).
+///
+/// Kept `@usableFromInline` so it can back the public Schnorr / ECDH / MuSig / Signing
+/// x-only key types across `Sources/Shared/*` without widening the public API surface.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 @usableFromInline struct XonlyKeyImplementation: Sendable {
-    /// The 32-byte X coordinate of the x-only public key, as output by `secp256k1_xonly_pubkey_serialize`.
+    /// The 32-byte X coordinate of the x-only public key, as output by
+    /// `secp256k1_xonly_pubkey_serialize`.
+    ///
+    /// Stable wire format suitable for persistence and transmission as a BIP-340-style
+    /// key identifier.
     @usableFromInline let bytes: [UInt8]
 
-    /// Parity of the original public key's Y coordinate before x-only conversion: 0 if Y was even, 1 if Y was odd (negated). Returned by `secp256k1_xonly_pubkey_from_pubkey`.
+    /// Parity of the original public key's Y coordinate before x-only conversion:
+    /// `0` if Y was even, `1` if Y was odd (negated). Returned by
+    /// `secp256k1_xonly_pubkey_from_pubkey`.
+    ///
+    /// Required to reconstruct the full `(x, y)` point from the x-only form and
+    /// consulted during BIP-341 Taproot tweak verification.
     @usableFromInline let keyParity: Int32
 
-    /// Serialized MuSig2 public key aggregation cache. Empty for non-aggregated keys.
+    /// Serialized MuSig2 public-key aggregation cache. Empty for non-aggregated keys.
+    ///
+    /// Holds the 197-byte opaque `secp256k1_musig_keyagg_cache` struct body required
+    /// for continued signing / tweaking against this aggregate. Not a stable
+    /// serialization format — treat as a within-process session token.
     @usableFromInline let cache: [UInt8]
 
     /// The 32-byte X coordinate as `Data`.

--- a/Sources/Shared/MuSig/MuSig+Aggregate.swift
+++ b/Sources/Shared/MuSig/MuSig+Aggregate.swift
@@ -22,15 +22,23 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.MuSig {
-        /// Aggregates N secp256k1 public keys into a single MuSig2 aggregate public key via `secp256k1_musig_pubkey_agg`, sorting keys first with `secp256k1_ec_pubkey_sort` so the result is order-independent.
+        /// Aggregates N secp256k1 public keys into a single
+        /// [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki) MuSig2
+        /// aggregate public key via `secp256k1_musig_pubkey_agg`, sorting keys first with
+        /// `secp256k1_ec_pubkey_sort` so the result is order-independent. Upstream
+        /// reference:
+        /// [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h).
         ///
-        /// The returned ``PublicKey`` includes the 197-byte `secp256k1_musig_keyagg_cache` needed
-        /// for signing sessions and Taproot tweaking. Different orderings of the same multiset of
-        /// public keys produce the same aggregate because keys are sorted before aggregation.
+        /// The returned ``PublicKey`` includes the 197-byte `secp256k1_musig_keyagg_cache`
+        /// needed for signing sessions and Taproot tweaking. Different orderings of the
+        /// same multiset of public keys produce the same aggregate because keys are sorted
+        /// before aggregation.
         ///
-        /// - Parameter pubkeys: All signers' ``P256K/Schnorr/PublicKey`` values; must contain at least one key.
+        /// - Parameter pubkeys: All signers' ``P256K/Schnorr/PublicKey`` values; must
+        ///   contain at least one key.
         /// - Returns: An aggregate ``PublicKey`` with an embedded key aggregation cache.
-        /// - Throws: ``secp256k1Error/underlyingCryptoError`` if sorting or aggregation fails.
+        /// - Throws: ``secp256k1Error/underlyingCryptoError`` if sorting or aggregation
+        ///   fails.
         static func aggregate(_ pubkeys: [P256K.Schnorr.PublicKey]) throws -> P256K.MuSig.PublicKey {
             let context = P256K.Context.rawRepresentation
             let format = P256K.Format.compressed
@@ -66,14 +74,36 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.MuSig {
-        /// 64-byte BIP-340 Schnorr signature produced by ``aggregateSignatures(_:)`` from all signers' ``P256K/Schnorr/PartialSignature`` values; verifiable against the MuSig2 aggregate public key.
+        /// 64-byte
+        /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr
+        /// signature produced by ``aggregateSignatures(_:)`` from all signers'
+        /// ``P256K/Schnorr/PartialSignature`` values; verifiable against the MuSig2
+        /// aggregate public key.
         ///
-        /// The aggregate signature is a standard BIP-340 Schnorr signature and verifies with
-        /// `secp256k1_schnorrsig_verify` against the ``XonlyKey`` from ``aggregate(_:)``.
-        /// Note: `secp256k1_musig_partial_sig_agg` returning `1` does **not** guarantee the
-        /// resulting signature is valid — always verify with ``XonlyKey/isValidSignature(_:for:)``.
+        /// ## Overview
+        ///
+        /// The aggregate signature is a standard BIP-340 Schnorr signature and verifies
+        /// with `secp256k1_schnorrsig_verify` against the ``XonlyKey`` from
+        /// ``aggregate(_:)``. This is what makes MuSig2 useful: downstream verifiers
+        /// cannot distinguish an aggregate from a single-signer BIP-340 signature.
+        ///
+        /// > Important: `secp256k1_musig_partial_sig_agg` returning `1` does **not**
+        /// > guarantee the resulting signature is valid — always verify with
+        /// > ``XonlyKey/isValidSignature(_:for:)``.
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init(dataRepresentation:)``
+        ///
+        /// ### Serialization
+        /// - ``dataRepresentation``
         struct AggregateSignature: ContiguousBytes, DataSignature {
             /// The 64-byte BIP-340 Schnorr signature (`R.x || s` in big-endian).
+            ///
+            /// Stable wire format identical to a single-signer BIP-340 signature. Produced
+            /// by `secp256k1_musig_partial_sig_agg` after all signers submit their
+            /// partial signatures.
             public var dataRepresentation: Data
 
             /// Creates an ``AggregateSignature`` from a 64-byte raw representation.
@@ -107,15 +137,20 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.MuSig {
-        /// Combines all signers' partial signatures into a final 64-byte ``AggregateSignature`` via `secp256k1_musig_partial_sig_agg`.
+        /// Combines all signers' partial signatures into a final 64-byte
+        /// ``AggregateSignature`` via `secp256k1_musig_partial_sig_agg`.
         ///
-        /// A return value of `1` from the underlying C function does **not** guarantee the result
-        /// verifies — always call ``XonlyKey/isValidSignature(_:for:)`` on the output to confirm
-        /// the aggregate signature is valid against the aggregate public key.
+        /// > Important: A return value of `1` from the underlying C function does **not**
+        /// > guarantee the result verifies — always call
+        /// > ``XonlyKey/isValidSignature(_:for:)`` on the output to confirm the aggregate
+        /// > signature is valid against the aggregate public key.
         ///
-        /// - Parameter partialSignatures: All signers' ``P256K/Schnorr/PartialSignature`` values; must include every participant's partial signature.
-        /// - Returns: A 64-byte ``AggregateSignature`` that may be verified with `secp256k1_schnorrsig_verify`.
-        /// - Throws: ``secp256k1Error/underlyingCryptoError`` if `secp256k1_musig_partial_sig_agg` fails.
+        /// - Parameter partialSignatures: All signers' ``P256K/Schnorr/PartialSignature``
+        ///   values; must include every participant's partial signature.
+        /// - Returns: A 64-byte ``AggregateSignature`` that may be verified with
+        ///   `secp256k1_schnorrsig_verify`.
+        /// - Throws: ``secp256k1Error/underlyingCryptoError`` if
+        ///   `secp256k1_musig_partial_sig_agg` fails.
         static func aggregateSignatures(
             _ partialSignatures: [P256K.Schnorr.PartialSignature]
         ) throws -> P256K.MuSig.AggregateSignature {
@@ -145,15 +180,49 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr {
-        /// 36-byte MuSig2 partial signature produced by one signer via ``P256K/Schnorr/PrivateKey/partialSignature(for:pubnonce:secureNonce:publicNonceAggregate:xonlyKeyAggregate:)``; combined with all others by ``P256K/MuSig/aggregateSignatures(_:)``.
+        /// MuSig2 partial signature produced by one signer via
+        /// ``P256K/Schnorr/PrivateKey/partialSignature(for:pubnonce:secureNonce:publicNonceAggregate:xonlyKeyAggregate:)``;
+        /// combined with all others by ``P256K/MuSig/aggregateSignatures(_:)``.
         ///
-        /// Each signer produces one ``PartialSignature`` per signing session. The partial signature
-        /// does **not** verify as a standalone signature; it only becomes valid after all partial
-        /// signatures are aggregated into a ``P256K/MuSig/AggregateSignature``.
+        /// ## Overview
+        ///
+        /// Each signer produces one ``PartialSignature`` per signing session. The partial
+        /// signature does **not** verify as a standalone signature; it only becomes valid
+        /// after all partial signatures are aggregated into a
+        /// ``P256K/MuSig/AggregateSignature``.
+        ///
+        /// Internally the signature bytes are the opaque 36-byte `secp256k1_musig_partial_sig`
+        /// struct body. The wire format is 32 bytes, produced by
+        /// `secp256k1_musig_partial_sig_serialize` and consumed by
+        /// `secp256k1_musig_partial_sig_parse`. See
+        /// [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h)
+        /// for the upstream declarations.
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init(dataRepresentation:session:)``
+        ///
+        /// ### Inspection
+        /// - ``dataRepresentation``
+        /// - ``session``
         struct PartialSignature: ContiguousBytes {
-            /// The raw 36-byte `secp256k1_musig_partial_sig` data.
+            /// The opaque 36-byte `secp256k1_musig_partial_sig` struct bytes.
+            ///
+            /// The in-memory struct layout is not a stable wire format across libsecp256k1
+            /// versions — the 32-byte wire form comes from
+            /// `secp256k1_musig_partial_sig_serialize`. The full 36-byte buffer is retained
+            /// here because the Swift layer passes it directly into
+            /// `secp256k1_musig_partial_sig_agg` without re-parsing.
             public var dataRepresentation: Data
-            /// The 133-byte `secp256k1_musig_session` state required for aggregation and verification.
+
+            /// The 133-byte `secp256k1_musig_session` state required for aggregation and
+            /// verification.
+            ///
+            /// Opaque upstream struct holding the per-session state (aggregate nonce,
+            /// message hash, tweak state, etc.) populated by `secp256k1_musig_nonce_process`
+            /// and consumed by `secp256k1_musig_partial_sig_agg`. Treat as a within-process
+            /// session token; not a stable serialization format.
             public var session: Data
 
             /// Creates a ``PartialSignature`` from raw partial signature bytes and session data.

--- a/Sources/Shared/MuSig/MuSig+Nonces.swift
+++ b/Sources/Shared/MuSig/MuSig+Nonces.swift
@@ -23,13 +23,32 @@ public import Foundation
         /// The byte length of a serialized MuSig2 aggregated nonce: 66 bytes (two 33-byte compressed points in BIP-327 wire format).
         static let aggregatedNonceByteCount = 66
 
-        /// 66-byte aggregated MuSig2 public nonce produced by `secp256k1_musig_nonce_agg` from all signers' individual public nonces, required before any partial signing can occur.
+        /// 66-byte aggregated MuSig2 public nonce produced by `secp256k1_musig_nonce_agg`
+        /// from all signers' individual public nonces, required before any partial signing
+        /// can occur.
         ///
-        /// The aggregated nonce is computed once from all signers' ``P256K/Schnorr/Nonce`` values
-        /// and then shared with every signer before they call
+        /// ## Overview
+        ///
+        /// Aggregation is specified in
+        /// [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki) and
+        /// implemented in
+        /// [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h).
+        /// The aggregated nonce is computed once from all signers' ``P256K/Schnorr/Nonce``
+        /// values and then shared with every signer before they call
         /// ``P256K/Schnorr/PrivateKey/partialSignature(for:pubnonce:secureNonce:publicNonceAggregate:xonlyKeyAggregate:)``.
-        /// An untrusted aggregator may compute the aggregate nonce; if the result is wrong, the
-        /// final signature will simply be invalid rather than leaking key material.
+        /// An untrusted aggregator may compute the aggregate nonce; if the result is wrong,
+        /// the final signature will simply be invalid rather than leaking key material.
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init(dataRepresentation:)``
+        /// - ``init(aggregating:)``
+        /// - ``generate(secretKey:publicKey:msg32:extraInput32:)``
+        /// - ``generate(sessionID:secretKey:publicKey:msg32:extraInput32:)``
+        ///
+        /// ### Serialization
+        /// - ``dataRepresentation``
         struct Nonce: ContiguousBytes, Sequence {
             /// The raw 66-byte `secp256k1_musig_aggnonce` struct bytes.
             let aggregatedNonce: Data

--- a/Sources/Shared/MuSig/MuSig+Signing.swift
+++ b/Sources/Shared/MuSig/MuSig+Signing.swift
@@ -20,11 +20,16 @@ import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.MuSig.PublicKey {
-        /// Verifies one signer's ``P256K/Schnorr/PartialSignature`` against this aggregate public key using `secp256k1_musig_partial_sig_verify`.
+        /// Verifies one signer's ``P256K/Schnorr/PartialSignature`` against this aggregate
+        /// public key using `secp256k1_musig_partial_sig_verify` (declared in
+        /// [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h)).
         ///
-        /// Partial signature verification is optional in regular MuSig2 sessions — if any partial
-        /// signature is wrong, the final ``P256K/MuSig/AggregateSignature`` will simply fail to
-        /// verify. Call this method to identify *which* signer produced an invalid partial signature.
+        /// Partial signature verification is optional in regular
+        /// [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki) MuSig2
+        /// sessions — if any partial signature is wrong, the final
+        /// ``P256K/MuSig/AggregateSignature`` will simply fail to verify. Call this method
+        /// to identify *which* signer produced an invalid partial signature, which matters
+        /// when you need to attribute failure and evict a faulty cosigner.
         ///
         /// - Parameter partialSignature: The signer's ``P256K/Schnorr/PartialSignature`` to verify.
         /// - Parameter publicKey: The individual signer's ``P256K/Schnorr/PublicKey`` (not the aggregate).
@@ -65,16 +70,22 @@ import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr.PrivateKey {
-        /// Produces a 36-byte ``P256K/Schnorr/PartialSignature`` via `secp256k1_musig_partial_sign`, consuming and zeroing the secret nonce to prevent reuse.
+        /// Produces a ``P256K/Schnorr/PartialSignature`` via `secp256k1_musig_partial_sign`,
+        /// consuming and zeroing the secret nonce to prevent reuse. The resulting partial
+        /// signature is an opaque 36-byte in-memory struct; its stable wire format is
+        /// 32 bytes (see ``P256K/Schnorr/PartialSignature/dataRepresentation``).
         ///
-        /// > Warning: **The secret nonce is zeroed after this call.** `secp256k1_musig_partial_sign`
-        /// > overwrites `secureNonce` with zeros as a best-effort defence against nonce reuse;
-        /// > if `secureNonce` was copied beforehand, that copy must never be used again.
-        /// > Nonce reuse leaks the secret signing key.
+        /// > Warning: **The secret nonce is zeroed after this call.**
+        /// > `secp256k1_musig_partial_sign` overwrites `secureNonce` with zeros as a
+        /// > best-effort defence against nonce reuse. Because ``P256K/Schnorr/SecureNonce``
+        /// > is `~Copyable`, the Swift layer additionally prevents static misuse. Nonce
+        /// > reuse leaks the secret signing key.
         ///
         /// This method does **not** verify the output partial signature, deviating from the
-        /// BIP-327 specification. Call ``P256K/MuSig/PublicKey/isValidSignature(_:publicKey:nonce:for:)``
-        /// afterwards to detect computation errors.
+        /// [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)
+        /// specification. Call
+        /// ``P256K/MuSig/PublicKey/isValidSignature(_:publicKey:nonce:for:)`` afterwards to
+        /// detect computation errors.
         ///
         /// - Parameter digest: The message digest to sign.
         /// - Parameter pubnonce: This signer's own public nonce from nonce generation.

--- a/Sources/Shared/MuSig/MuSig+Tweak.swift
+++ b/Sources/Shared/MuSig/MuSig+Tweak.swift
@@ -20,11 +20,17 @@ import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.MuSig.PublicKey {
-        /// Creates a new ``PublicKey`` by computing `agg_pk' = agg_pk + G × tweak` via `secp256k1_musig_pubkey_ec_tweak_add`, updating the key aggregation cache in-place.
+        /// Creates a new ``PublicKey`` by computing `agg_pk' = agg_pk + G × tweak` via
+        /// `secp256k1_musig_pubkey_ec_tweak_add` (declared in
+        /// [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h)),
+        /// updating the key aggregation cache in-place.
         ///
-        /// Use this method when you need to sign for a BIP-32 child key derived from the aggregate
-        /// key. If you only need the tweaked public key for verification (not signing), use
-        /// `secp256k1_ec_pubkey_tweak_add` directly instead.
+        /// Use this method when you need to **sign** for a
+        /// [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) child
+        /// key derived from the aggregate. The cache update ensures the subsequent partial
+        /// signatures verify against the tweaked aggregate. If you only need the tweaked
+        /// public key for verification (not signing), use `secp256k1_ec_pubkey_tweak_add`
+        /// directly instead.
         ///
         /// - Parameter tweak: A 32-byte tweak scalar; must pass `secp256k1_ec_seckey_verify` and must not negate the aggregate key.
         /// - Parameter format: The serialization format of the returned ``PublicKey``; defaults to `.compressed`.
@@ -58,11 +64,17 @@ import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.MuSig.XonlyKey {
-        /// Creates a new ``XonlyKey`` by computing `agg_pk' = agg_pk + G × tweak` via `secp256k1_musig_pubkey_xonly_tweak_add`, as required for BIP-341 Taproot output key construction.
+        /// Creates a new ``XonlyKey`` by computing `agg_pk' = agg_pk + G × tweak` via
+        /// `secp256k1_musig_pubkey_xonly_tweak_add`, as required for
+        /// [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) Taproot
+        /// output key construction.
         ///
-        /// Use this method to produce Taproot outputs where `tweak` is the TapTweak hash (BIP-341).
-        /// This method is required if you want to *sign* for the tweaked aggregate key. If you only
-        /// need the tweaked public key and are not signing, use `secp256k1_xonly_pubkey_tweak_add`.
+        /// Use this method to produce Taproot outputs where `tweak` is the `TapTweak`
+        /// tagged-SHA256 hash as specified by BIP-341. This method is required if you want
+        /// to *sign* for the tweaked aggregate key — it updates the key-aggregation cache
+        /// so subsequent MuSig partial signatures verify against the tweaked aggregate. If
+        /// you only need the tweaked public key and are not signing, use
+        /// `secp256k1_xonly_pubkey_tweak_add` directly instead.
         ///
         /// - Parameter tweak: A 32-byte tweak scalar; must pass `secp256k1_ec_seckey_verify` and must not negate the aggregate key.
         /// - Returns: A new ``XonlyKey`` representing the Taproot output key.

--- a/Sources/Shared/MuSig/MuSig.swift
+++ b/Sources/Shared/MuSig/MuSig.swift
@@ -20,15 +20,29 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K {
-        /// BIP-327 MuSig2 multi-signature namespace for secp256k1: aggregate signer public keys with ``aggregate(_:)``, coordinate nonce generation, collect partial signatures, and aggregate into a final 64-byte ``AggregateSignature``.
+        /// MuSig2 multi-signature namespace for secp256k1
+        /// ([BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)):
+        /// aggregate signer public keys with ``aggregate(_:)``, coordinate nonce generation,
+        /// collect partial signatures, and aggregate into a final 64-byte ``AggregateSignature``.
         ///
-        /// MuSig2 allows N parties to collaboratively produce a single BIP-340 Schnorr signature
-        /// that verifies against an aggregated public key (`secp256k1_musig_pubkey_agg`), without
-        /// revealing each signer's individual key. The aggregate key is indistinguishable from a
-        /// regular secp256k1 public key, making multi-signatures compatible with all Schnorr
-        /// verifiers including Taproot (BIP-341).
+        /// ## Overview
         ///
-        /// ## Signing Protocol Order
+        /// MuSig2 allows N parties to collaboratively produce a single
+        /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr
+        /// signature that verifies against an aggregated public key (`secp256k1_musig_pubkey_agg`),
+        /// without revealing each signer's individual key. The aggregate key is indistinguishable
+        /// from a regular secp256k1 public key, making multi-signatures compatible with all
+        /// Schnorr verifiers including Taproot
+        /// ([BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)).
+        ///
+        /// Key aggregation requires **no trusted dealer** — every signer runs the aggregation
+        /// locally and arrives at the same result by deterministic protocol. The upstream C
+        /// implementation
+        /// ([`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h))
+        /// is the normative reference for every method here; the Swift surface wraps those
+        /// functions with type-safe session state.
+        ///
+        /// ### Signing Protocol Order
         ///
         /// The upstream `secp256k1_musig.h` mandates a strict protocol order. Deviating from
         /// this order may produce invalid or insecure signatures:
@@ -39,44 +53,124 @@ public import Foundation
         /// 4. **Partial signing**: Each signer calls ``P256K/Schnorr/PrivateKey/partialSignature(for:pubnonce:secureNonce:publicNonceAggregate:xonlyKeyAggregate:)``.
         /// 5. **Signature aggregation**: Any party calls ``aggregateSignatures(_:)``.
         ///
-        /// ## Nonce Reuse
+        /// ### Nonce Reuse
         ///
         /// **Nonce reuse leaks the secret signing key.** The ``P256K/Schnorr/SecureNonce`` type is `~Copyable`
         /// to prevent accidental duplication. The underlying `secp256k1_musig_secnonce` struct is
         /// zeroed by `secp256k1_musig_partial_sign` after use; never copy or serialize the secret
         /// nonce bytes. Always provide a unique `sessionID` per signing session.
+        ///
+        /// ### Taproot Compatibility
+        ///
+        /// The aggregate public key's ``PublicKey/xonly`` form is directly usable as a BIP-341
+        /// Taproot internal key, and the aggregate signature is a valid BIP-340 Schnorr
+        /// signature over the aggregate x-only key. Consumers can therefore MuSig-aggregate
+        /// N cosigners and plug the result into any Taproot-compatible wallet or script-path
+        /// without a custom verifier.
+        ///
+        /// ## Topics
+        ///
+        /// ### Aggregation
+        /// - ``PublicKey``
+        /// - ``XonlyKey``
+        /// - ``aggregate(_:)``
+        /// - ``aggregateSignatures(_:)``
+        ///
+        /// ### Session Types
+        /// - ``AggregateSignature``
         enum MuSig {
             /// secp256k1 MuSig2 aggregate public key produced by ``aggregate(_:)`` via `secp256k1_musig_pubkey_agg`, used for partial signature verification and Taproot tweaking.
+            ///
+            /// An aggregate public key is indistinguishable from a single-signer secp256k1
+            /// public key by any external observer, which is precisely what gives MuSig2 its
+            /// Taproot compatibility. Internally the key carries the 197-byte
+            /// `secp256k1_musig_keyagg_cache` produced by `secp256k1_musig_pubkey_agg`; that
+            /// cache is required to reconstruct the key-aggregation coefficients during the
+            /// partial-signing phase and **must** be preserved alongside the public-key bytes
+            /// when serializing the aggregate across a process boundary.
+            ///
+            /// ## Topics
+            ///
+            /// ### Serialized Forms
+            /// - ``dataRepresentation``
+            /// - ``format``
+            /// - ``xonly``
+            ///
+            /// ### Reconstruction
+            /// - ``init(xonlyKey:)``
+            /// - ``init(dataRepresentation:format:cache:)``
             public struct PublicKey {
-                /// The internal backing public key implementation.
+                /// The internal ``PublicKeyImplementation`` backing this aggregate, produced
+                /// by `secp256k1_musig_pubkey_agg` and carrying the 197-byte
+                /// `secp256k1_musig_keyagg_cache` required for signing sessions.
+                ///
+                /// Kept `internal` — consumers never see or manipulate the raw C cache through
+                /// the public API; they must round-trip via ``dataRepresentation`` + ``xonly``
+                /// + the ``cache`` helper on ``XonlyKey`` when serializing the aggregate.
                 let baseKey: PublicKeyImplementation
 
                 /// The serialized public key bytes in the key's ``format``.
+                ///
+                /// Internal-visibility passthrough used by the Swift-side MuSig signing and
+                /// verification helpers. Callers should use ``dataRepresentation`` for
+                /// cross-boundary serialization.
                 var bytes: [UInt8] {
                     baseKey.bytes
                 }
 
-                /// The 197-byte opaque `secp256k1_musig_keyagg_cache` required for signing sessions and Taproot tweaking.
+                /// The 197-byte opaque `secp256k1_musig_keyagg_cache` required for signing
+                /// sessions and Taproot tweaking.
+                ///
+                /// Internal-visibility: the cache is an opaque upstream struct whose bytes
+                /// are **not** a stable serialization format across libsecp256k1 versions.
+                /// External persistence of the aggregate goes through ``xonly`` which exposes
+                /// the cache alongside a stable 32-byte x-only identifier.
                 var keyAggregationCache: Data {
                     Data(baseKey.cache)
                 }
 
-                /// The serialization format of this public key: `.compressed` (33 bytes) or `.uncompressed` (65 bytes).
+                /// The serialization format of this public key: `.compressed` (33 bytes) or
+                /// `.uncompressed` (65 bytes).
+                ///
+                /// Inherited from whichever format was used when aggregating or reconstructing
+                /// the key. Most Bitcoin / Taproot workflows use ``P256K/Format/compressed``;
+                /// ``P256K/Format/uncompressed`` is supported for interoperability with
+                /// legacy systems that require the full `(x, y)` point encoding.
                 public var format: P256K.Format {
                     baseKey.format
                 }
 
                 /// The serialized public key bytes as `Data`, in the key's ``format``.
+                ///
+                /// Suitable for transmission and storage. **Note**: for full reconstruction
+                /// on the receiving side, you must also transmit the ``XonlyKey/cache`` from
+                /// ``xonly`` — the raw bytes alone do not carry the MuSig key-aggregation
+                /// coefficients required for the partial-signing phase.
                 public var dataRepresentation: Data {
                     baseKey.dataRepresentation
                 }
 
-                /// The 32-byte x-only form of this aggregate public key for BIP-340 Schnorr signature verification and Taproot output construction.
+                /// The 32-byte x-only form of this aggregate public key for BIP-340 Schnorr
+                /// signature verification and Taproot output construction.
+                ///
+                /// The x-only form is the **canonical** external representation for a MuSig
+                /// aggregate: it matches what a BIP-340 verifier expects, and its parity bit
+                /// is exactly what a BIP-341 Taproot output-key derivation consumes. The
+                /// returned ``XonlyKey`` also carries the 197-byte keyagg cache required for
+                /// future signing sessions against this aggregate.
                 public var xonly: XonlyKey {
                     XonlyKey(baseKey: baseKey.xonly)
                 }
 
                 /// Creates a MuSig public key from a validated backing implementation.
+                ///
+                /// Internal-visibility constructor used by ``aggregate(_:)`` after
+                /// `secp256k1_musig_pubkey_agg` returns successfully. Consumers reconstruct
+                /// via ``init(xonlyKey:)`` or ``init(dataRepresentation:format:cache:)``
+                /// instead.
+                ///
+                /// - Parameter baseKey: A ``PublicKeyImplementation`` produced by the upstream
+                ///   C aggregation call, with its 197-byte keyagg cache populated.
                 init(baseKey: PublicKeyImplementation) {
                     self.baseKey = baseKey
                 }
@@ -112,27 +206,72 @@ public import Foundation
                 }
             }
 
-            /// The 32-byte x-only form of a MuSig2 aggregate public key, used for BIP-340 Schnorr signature verification and Taproot tweaking via ``add(_:)``.
+            /// The 32-byte x-only form of a MuSig2 aggregate public key, used for BIP-340
+            /// Schnorr signature verification and Taproot tweaking via ``add(_:)``.
+            ///
+            /// X-only keys drop the Y-coordinate parity bit from the standard 33-byte
+            /// compressed encoding, matching the representation BIP-340 verifiers consume
+            /// directly. The 1-bit parity is retained separately as ``parity`` so Taproot
+            /// tweak verification can reconstruct the full point when computing `t * G` and
+            /// the subsequent conditional negation.
+            ///
+            /// ## Topics
+            ///
+            /// ### Inspection
+            /// - ``bytes``
+            /// - ``parity``
+            /// - ``cache``
+            ///
+            /// ### Reconstruction
+            /// - ``init(dataRepresentation:keyParity:cache:)``
             public struct XonlyKey: Equatable {
-                /// The internal backing x-only key implementation.
+                /// The internal ``XonlyKeyImplementation`` backing this aggregate x-only key.
+                ///
+                /// Kept `private` — the backing type is an internal convenience over the
+                /// upstream `secp256k1_xonly_pubkey` struct; consumers never see or manipulate
+                /// it directly through the public API.
                 private let baseKey: XonlyKeyImplementation
 
                 /// The 32-byte X coordinate of the aggregate public key.
+                ///
+                /// Stable across libsecp256k1 versions — safe to persist as a Bitcoin-
+                /// address-style identifier. Pair with ``parity`` and ``cache`` when the
+                /// aggregate needs to be reconstructed for a future signing session.
                 public var bytes: [UInt8] {
                     baseKey.bytes
                 }
 
-                /// The parity of the aggregate public key's Y coordinate, as returned by `secp256k1_xonly_pubkey_from_pubkey`; used in Taproot tweak verification.
+                /// The parity of the aggregate public key's Y coordinate, as returned by
+                /// `secp256k1_xonly_pubkey_from_pubkey`; used in Taproot tweak verification.
+                ///
+                /// `true` = odd Y, `false` = even Y. BIP-340 signatures are verified against
+                /// the even-Y representative of a point, so the parity bit is tracked
+                /// separately and consulted during tweak verification (`secp256k1_musig_pubkey_xonly_tweak_add_check`)
+                /// and the Taproot output-key derivation (`secp256k1_xonly_pubkey_tweak_add_check`).
                 public var parity: Bool {
                     baseKey.keyParity.boolValue
                 }
 
-                /// The 197-byte opaque `secp256k1_musig_keyagg_cache` required for Taproot tweaking and signing sessions; must be preserved alongside the key bytes.
+                /// The 197-byte opaque `secp256k1_musig_keyagg_cache` required for Taproot
+                /// tweaking and signing sessions; must be preserved alongside the key bytes.
+                ///
+                /// The cache bytes are **not** a stable serialization format across
+                /// libsecp256k1 versions — treat them as a within-process session token.
+                /// For cross-process persistence, store them in an ephemeral location
+                /// (e.g. alongside a one-shot signing session's other state) rather than
+                /// in long-lived configuration.
                 public var cache: Data {
                     Data(baseKey.cache)
                 }
 
                 /// Creates a MuSig x-only key from a validated backing implementation.
+                ///
+                /// Internal-visibility constructor used by the aggregate public key's
+                /// ``PublicKey/xonly`` accessor; consumers reconstruct via the public
+                /// initializer below.
+                ///
+                /// - Parameter baseKey: A ``XonlyKeyImplementation`` produced by the upstream
+                ///   C conversion from an aggregate `secp256k1_pubkey`.
                 init(baseKey: XonlyKeyImplementation) {
                     self.baseKey = baseKey
                 }

--- a/Sources/Shared/Recovery/Recovery+Signature.swift
+++ b/Sources/Shared/Recovery/Recovery+Signature.swift
@@ -20,24 +20,77 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Recovery {
-        /// A 64-byte compact ECDSA signature paired with its 1-byte recovery ID, as produced by `secp256k1_ecdsa_recoverable_signature_serialize_compact`.
+        /// A 64-byte compact ECDSA signature paired with its 1-byte recovery ID, as
+        /// produced by `secp256k1_ecdsa_recoverable_signature_serialize_compact` (declared
+        /// in
+        /// [`Vendor/secp256k1/include/secp256k1_recovery.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_recovery.h)).
+        ///
+        /// This is the canonical wire format for Bitcoin signed-message payloads
+        /// ([BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki),
+        /// [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki)):
+        /// 64 bytes of ECDSA compact signature plus 1 separate byte for the recovery ID.
+        ///
+        /// ## Topics
+        ///
+        /// ### Fields
+        /// - ``signature``
+        /// - ``recoveryId``
         struct ECDSACompactSignature {
-            /// The 64-byte compact ECDSA signature (`r || s`).
+            /// The 64-byte compact ECDSA signature (`r || s`, big-endian).
+            ///
+            /// Same byte layout as ``P256K/Signing/ECDSASignature/compactRepresentation`` —
+            /// pair with ``recoveryId`` to transmit both halves separately, or concatenate
+            /// as `signature || UInt8(recoveryId)` for the 65-byte combined form used by
+            /// Bitcoin signed-message workflows.
             public let signature: Data
-            /// The recovery ID (0–3) that identifies which of the possible public keys corresponds to the signer.
+
+            /// The recovery ID (`0–3`) that identifies which of the possible public keys
+            /// corresponds to the signer.
+            ///
+            /// For any valid `(message, signature)` pair there are up to four candidate
+            /// public keys that satisfy the verification equation. The signer records the
+            /// correct one as this 2-bit value (stored as `Int32` for easy upstream API
+            /// interop). Values `≥ 4` are invalid and reflect a corrupted signature.
             public let recoveryId: Int32
         }
 
-        /// 65-byte secp256k1 ECDSA recoverable signature (64-byte compact form + 1-byte recovery ID) produced by `secp256k1_ecdsa_sign_recoverable` using RFC 6979 deterministic nonces.
+        /// 65-byte secp256k1 ECDSA recoverable signature (64-byte compact form + 1-byte
+        /// recovery ID) produced by `secp256k1_ecdsa_sign_recoverable` using
+        /// [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979) deterministic nonces.
         ///
-        /// A recoverable signature allows ``PublicKey`` to be reconstructed from the message hash
-        /// alone via `secp256k1_ecdsa_recover`. Successful recovery guarantees the signature would
-        /// pass `secp256k1_ecdsa_verify` **after normalization**; however, converting the signature
-        /// to a non-recoverable form via ``normalize`` does **not** automatically normalize it.
-        /// Call `secp256k1_ecdsa_signature_normalize` on the result of ``normalize`` if lower-S
-        /// normalized form is required for standard ECDSA verification.
+        /// ## Overview
+        ///
+        /// A recoverable signature allows ``PublicKey`` to be reconstructed from the
+        /// message hash alone via `secp256k1_ecdsa_recover`. Successful recovery guarantees
+        /// the signature would pass `secp256k1_ecdsa_verify` **after normalization**;
+        /// however, converting the signature to a non-recoverable form via ``normalize``
+        /// does **not** automatically normalize it. Call
+        /// `secp256k1_ecdsa_signature_normalize` on the result of ``normalize`` if lower-S
+        /// normalized form is required for standard ECDSA verification per
+        /// [BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki).
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init(dataRepresentation:)``
+        /// - ``init(compactRepresentation:recoveryId:)``
+        ///
+        /// ### Serialization
+        /// - ``dataRepresentation``
+        /// - ``compactRepresentation``
+        ///
+        /// ### Conversion
+        /// - ``normalize``
         struct ECDSASignature: ContiguousBytes, DataSignature {
-            /// The raw 65-byte internal representation of the `secp256k1_ecdsa_recoverable_signature` struct.
+            /// The raw 65-byte internal representation of the
+            /// `secp256k1_ecdsa_recoverable_signature` struct.
+            ///
+            /// The internal layout is the opaque upstream struct body (declared as
+            /// `unsigned char data[65]` in
+            /// [`Vendor/secp256k1/include/secp256k1_recovery.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_recovery.h)).
+            /// It is **not** a stable wire format across libsecp256k1 versions — for
+            /// cross-process persistence, use ``compactRepresentation`` and transmit the
+            /// `signature + recoveryId` bytes alongside each other.
             public var dataRepresentation: Data
 
             /// The 64-byte compact serialization and 1-byte recovery ID, produced by `secp256k1_ecdsa_recoverable_signature_serialize_compact`.
@@ -67,8 +120,8 @@ public import Foundation
             /// Converts this recoverable signature to a standard ``P256K/Signing/ECDSASignature`` via `secp256k1_ecdsa_recoverable_signature_convert`.
             ///
             /// > Important: The converted signature is **not guaranteed to be lower-S normalized**
-            /// > and may fail `secp256k1_ecdsa_verify`. If normalized form is required, call
-            /// > ``P256K/Signing/ECDSASignature/normalize`` on the result.
+            /// > and may fail `secp256k1_ecdsa_verify`. If normalized form is required, pass the
+            /// > result through `secp256k1_ecdsa_signature_normalize` before verifying.
             public var normalize: P256K.Signing.ECDSASignature {
                 let context = P256K.Context.rawRepresentation
                 var normalizedSignature = secp256k1_ecdsa_signature()

--- a/Sources/Shared/Recovery/Recovery.swift
+++ b/Sources/Shared/Recovery/Recovery.swift
@@ -22,29 +22,93 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K {
-        /// secp256k1 ECDSA recoverable signature namespace: sign with ``PrivateKey`` to produce an ``ECDSASignature`` that allows any verifier to recover the signer's ``PublicKey`` without prior knowledge.
+        /// secp256k1 ECDSA recoverable signature namespace: sign with ``PrivateKey`` to produce
+        /// an ``ECDSASignature`` that allows any verifier to recover the signer's ``PublicKey``
+        /// without prior knowledge.
         ///
-        /// Recoverable signatures are 65 bytes (64-byte compact ECDSA signature + 1-byte recovery ID).
-        /// They are produced by `secp256k1_ecdsa_sign_recoverable` and allow the signing public key
-        /// to be recovered via `secp256k1_ecdsa_recover` given only the message hash.
+        /// ## Overview
+        ///
+        /// Recoverable signatures are 65 bytes (64-byte compact ECDSA signature + 1-byte
+        /// recovery ID). They are produced by `secp256k1_ecdsa_sign_recoverable` and allow the
+        /// signing public key to be recovered via `secp256k1_ecdsa_recover` given only the
+        /// message hash. See
+        /// [`Vendor/secp256k1/include/secp256k1_recovery.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_recovery.h)
+        /// for the upstream API reference.
+        ///
+        /// Bitcoin's
+        /// [BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki) and
+        /// [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki)
+        /// "signed message" formats rely on this primitive for address-from-signature
+        /// recovery. Recoverability trades one byte of signature size for the ability to skip
+        /// transmitting the public key — a win whenever the signer and verifier share only a
+        /// message and want to establish identity without a pre-exchanged key. The
+        /// deterministic-nonce convention follows
+        /// [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979), as with all ECDSA
+        /// signing in this library.
         ///
         /// > Important: A recoverable signature that successfully passes `secp256k1_ecdsa_recover`
         /// > is **not guaranteed to pass** `secp256k1_ecdsa_verify` after conversion, because the
         /// > converted signature may not be in lower-S normalized form. Call
         /// > `secp256k1_ecdsa_signature_normalize` after
         /// > ``ECDSASignature/normalize`` if you need a signature that passes standard ECDSA verification.
+        ///
+        /// > Warning: **Recovery is not verification.** A successfully-recovered key is merely
+        /// > a candidate public key whose signature of the given message would be this exact
+        /// > byte pattern. To confirm the candidate is the *expected* signer, compare it to
+        /// > the known-authentic public key via constant-time equality (e.g. `safeCompare`).
+        /// > Never trust a recovered key as-authenticated without that compare step.
+        ///
+        /// ## Topics
+        ///
+        /// ### Key Types
+        /// - ``PrivateKey``
+        /// - ``PublicKey``
+        ///
+        /// ### Signature Types
+        /// - ``ECDSASignature``
         enum Recovery {
-            /// secp256k1 ECDSA private key for producing recoverable signatures via `secp256k1_ecdsa_sign_recoverable` with RFC 6979 deterministic nonce generation.
+            /// secp256k1 ECDSA private key for producing recoverable signatures via
+            /// `secp256k1_ecdsa_sign_recoverable` with RFC 6979 deterministic nonce generation.
+            ///
+            /// Semantically a distinct type from ``P256K/Signing/PrivateKey`` only because its
+            /// associated ``PublicKey`` recovers via `secp256k1_ecdsa_recover` rather than being
+            /// transmitted alongside the signature. The underlying 32-byte scalar is identical;
+            /// the two Swift types differ in the method surface they expose.
+            ///
+            /// ## Topics
+            ///
+            /// ### Construction
+            /// - ``init(format:)``
+            /// - ``init(dataRepresentation:format:)``
+            ///
+            /// ### Inspection
+            /// - ``publicKey``
+            /// - ``dataRepresentation``
             public struct PrivateKey: Equatable {
-                /// The internal backing private key implementation.
+                /// The internal `PrivateKeyImplementation` backing this recoverable-signing key.
+                ///
+                /// Kept `private` — the backing type wraps the 32-byte secret scalar in
+                /// `SecureBytes`-style zeroizing storage; consumers interact only through
+                /// the public API surface.
                 private let baseKey: PrivateKeyImplementation
 
-                /// The secp256k1 public key derived from this private key.
+                /// The secp256k1 public key derived from this private key, as a ``Recovery/PublicKey``.
+                ///
+                /// Computed on every access via `secp256k1_ec_pubkey_create`. For high-frequency
+                /// signing loops, cache the value locally rather than re-deriving it per call.
+                /// The returned public key carries the private key's ``P256K/Format`` selection.
                 public var publicKey: PublicKey {
                     PublicKey(baseKey: baseKey.publicKey)
                 }
 
-                /// The raw 32-byte private key as `Data`. Keep this value confidential; disclosure allows anyone to sign on your behalf.
+                /// The raw 32-byte private key as `Data`. Keep this value confidential; disclosure
+                /// allows anyone to sign on your behalf.
+                ///
+                /// The bytes are zeroed when the backing `PrivateKeyImplementation` is
+                /// deallocated, but **copies made through this accessor are not**: any `Data`
+                /// produced here escapes the zeroization scope and must be handled by the caller.
+                /// Prefer restricting its reach to the minimum necessary scope (e.g. one encrypted
+                /// write to a keychain) before discarding.
                 public var dataRepresentation: Data {
                     baseKey.dataRepresentation
                 }
@@ -77,12 +141,34 @@ public import Foundation
                 }
             }
 
-            /// secp256k1 public key recovered from an ``ECDSASignature`` via `secp256k1_ecdsa_recover`, identifying the signer without prior knowledge of their public key.
+            /// secp256k1 public key recovered from an ``ECDSASignature`` via
+            /// `secp256k1_ecdsa_recover`, identifying the signer without prior knowledge of
+            /// their public key.
+            ///
+            /// A recovered public key is mathematically a *candidate* — any signature has up
+            /// to four valid recovery IDs, each producing a different candidate key. The
+            /// 1-byte recovery ID stored in the ``ECDSASignature`` disambiguates which
+            /// candidate the original signer chose. Always treat the recovered key as
+            /// unauthenticated material until compared to a known reference.
+            ///
+            /// ## Topics
+            ///
+            /// ### Inspection
+            /// - ``dataRepresentation``
             public struct PublicKey {
-                /// The internal backing public key implementation.
+                /// The internal `PublicKeyImplementation` backing this recovered key.
+                ///
+                /// Kept `internal` — the backing type wraps the 64-byte upstream
+                /// `secp256k1_pubkey` struct plus serialization format; consumers never see
+                /// the raw C handle through the public API.
                 let baseKey: PublicKeyImplementation
 
                 /// The serialized public key bytes as `Data`, in the key's format.
+                ///
+                /// Suitable for comparison with a known-authentic public key via constant-time
+                /// equality (see `safeCompare`) to authenticate the recovery result. The
+                /// format (``P256K/Format/compressed`` or ``P256K/Format/uncompressed``) is
+                /// inherited from the `format:` argument passed to the recovery initializer.
                 public var dataRepresentation: Data {
                     baseKey.dataRepresentation
                 }

--- a/Sources/Shared/SHA256.swift
+++ b/Sources/Shared/SHA256.swift
@@ -16,16 +16,44 @@ public import Foundation
     import libsecp256k1
 #endif
 
-/// SHA-256 hash function backed by `secp256k1_swift_sha256`, producing 32-byte ``SHA256Digest`` values; also provides BIP-340 tagged hash support via ``taggedHash(tag:data:)`` using `secp256k1_tagged_sha256`.
+/// SHA-256 hash function
+/// ([RFC 6234](https://datatracker.ietf.org/doc/html/rfc6234))
+/// backed by the `secp256k1_swift_sha256` shim
+/// ([`Sources/libsecp256k1/src/Utility.c`](https://github.com/21-DOT-DEV/swift-secp256k1/blob/main/Sources/libsecp256k1/src/Utility.c)),
+/// producing 32-byte ``SHA256Digest`` values; also provides BIP-340 tagged-hash support via
+/// ``taggedHash(tag:data:)`` using upstream `secp256k1_tagged_sha256`.
+///
+/// ## Overview
+///
+/// Re-exported from libsecp256k1's internal SHA-256 implementation rather than linking a
+/// separate hash library — this keeps the cryptographic dependency surface to a single
+/// audited component. The same implementation backs upstream signing and verification,
+/// so hashes produced here are byte-for-byte identical to the ones consumed by
+/// `secp256k1_schnorrsig_sign_custom`, `secp256k1_ecdsa_sign`, etc.
+///
+/// ## Topics
+///
+/// ### Hashing
+/// - ``hash(data:)``
+/// - ``taggedHash(tag:data:)``
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public enum SHA256 {
-    /// The number of bytes in a SHA256 digest.
+    /// The number of bytes in a SHA-256 digest (32).
+    ///
+    /// Fixed by the SHA-256 specification ([RFC 6234](https://datatracker.ietf.org/doc/html/rfc6234)):
+    /// the hash produces a 256-bit (32-byte) output regardless of input length. Used to
+    /// size output buffers for the upstream C helpers.
     @inlinable
     static var digestByteCount: Int {
         32
     }
 
-    /// Hashes `data` with SHA-256 via `secp256k1_swift_sha256` and returns a 32-byte ``SHA256Digest``.
+    /// Hashes `data` with SHA-256 via the `secp256k1_swift_sha256` shim and returns a
+    /// 32-byte ``SHA256Digest``.
+    ///
+    /// The shim wraps the internal libsecp256k1 SHA-256 implementation so the Swift layer
+    /// and the C layer share a single implementation for all hashing operations that feed
+    /// into signing / verification.
     ///
     /// - Parameter data: The data to hash; no length restriction.
     /// - Returns: A 32-byte ``SHA256Digest``.
@@ -38,12 +66,27 @@ public enum SHA256 {
         return .init(output)
     }
 
-    /// Computes a BIP-340 tagged hash `SHA256(SHA256(tag) || SHA256(tag) || data)` via `secp256k1_tagged_sha256`, producing a 32-byte ``SHA256Digest``.
+    /// Computes a BIP-340 tagged hash `SHA256(SHA256(tag) || SHA256(tag) || data)` via
+    /// upstream `secp256k1_tagged_sha256`, producing a 32-byte ``SHA256Digest``.
     ///
-    /// Tagged hashes prevent cross-protocol attacks by domain-separating hashes with an application-specific `tag`.
-    /// BIP-340 uses this scheme for Schnorr signature challenges and key tweaks (e.g., tag `"BIP0340/challenge"`).
+    /// Tagged hashes prevent cross-protocol attacks by domain-separating hashes with an
+    /// application-specific `tag`. The construction is defined in
+    /// [BIP-340 § Design](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#design)
+    /// and reused throughout the Bitcoin Taproot stack:
     ///
-    /// - Parameter tag: The domain-separation tag bytes; repeated twice before `data` as specified by BIP-340.
+    /// - `"BIP0340/challenge"` for the Schnorr signing challenge
+    /// - `"BIP0340/nonce"` for BIP-340 nonce derivation
+    /// - `"BIP0340/aux"` for auxiliary-randomness mixing
+    /// - `"TapLeaf"`, `"TapBranch"`, `"TapTweak"`, `"TapSighash"` for
+    ///   [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) Taproot
+    ///
+    /// Because the upstream SHA-256 implementation is shared between this Swift surface and
+    /// libsecp256k1's internal signing / verification code, the tag-hash output here is
+    /// byte-for-byte identical to what a libsecp256k1 signer would compute internally for
+    /// the same `(tag, data)` pair.
+    ///
+    /// - Parameter tag: The domain-separation tag bytes; repeated twice before `data` as
+    ///   specified by BIP-340.
     /// - Parameter data: The message bytes to hash after the two tag hashes.
     /// - Returns: A 32-byte ``SHA256Digest``.
     public static func taggedHash<D: DataProtocol>(tag: D, data: D) -> SHA256Digest {

--- a/Sources/Shared/Schnorr/Schnorr+Nonces.swift
+++ b/Sources/Shared/Schnorr/Schnorr+Nonces.swift
@@ -20,41 +20,82 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr {
-        /// The byte length of a serialized public nonce.
+        /// The byte length of a BIP-327 serialized public nonce (66 bytes).
+        ///
+        /// Matches the `out66` buffer size of `secp256k1_musig_pubnonce_serialize` in
+        /// [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h).
+        /// The in-memory struct `secp256k1_musig_pubnonce` is 132 bytes; this serialized
+        /// form is the stable wire format.
         static let publicNonceByteCount = 66
 
-        /// Represents a secure nonce used for MuSig operations.
+        /// A signer's secret nonce for MuSig2 operations, modeled as `~Copyable` to prevent
+        /// accidental duplication and nonce reuse.
         ///
-        /// This struct is used to handle secure nonces in the MuSig signing process.
-        /// It's crucial not to reuse nonces across different signing sessions to maintain security.
+        /// > Warning: **Nonce reuse leaks the secret signing key.** The upstream
+        /// > `secp256k1_musig_partial_sign` zeroes the secnonce after use (see
+        /// > [`Vendor/secp256k1-zkp/include/secp256k1_musig.h`](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/include/secp256k1_musig.h)
+        /// > `secp256k1_musig_nonce_gen`: *"This function overwrites the given secnonce with
+        /// > zeros and will abort if given a secnonce that is all zeros."*). Never copy or
+        /// > serialize the secret nonce bytes; always provide a unique `sessionID` per
+        /// > signing session.
         struct SecureNonce: ~Copyable {
+            /// The opaque 132-byte `secp256k1_musig_secnonce` struct bytes.
+            ///
+            /// Internal-visibility storage; the `~Copyable` conformance prevents consumers
+            /// from accessing these bytes outside the one-shot partial-signing flow that
+            /// zeroes them after use.
             let data: Data
 
+            /// Wraps raw secret-nonce bytes produced by upstream nonce-generation helpers.
+            ///
+            /// Internal-visibility constructor; consumers obtain a `SecureNonce` only via
+            /// the MuSig nonce-generation entry points.
+            ///
+            /// - Parameter data: The 132-byte opaque `secp256k1_musig_secnonce` buffer.
             init(_ data: Data) {
                 self.data = data
             }
         }
 
-        /// Represents a public nonce used for MuSig operations.
+        /// A signer's public nonce for MuSig2 operations, exchanged between signers during
+        /// the nonce-aggregation phase of
+        /// [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki).
+        ///
+        /// Unlike ``SecureNonce``, a public nonce is safe to transmit and copy. The
+        /// internal representation is the opaque 132-byte `secp256k1_musig_pubnonce` struct;
+        /// the wire format is the 66-byte ``dataRepresentation`` produced by
+        /// `secp256k1_musig_pubnonce_serialize`.
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init(dataRepresentation:)``
+        ///
+        /// ### Serialization
+        /// - ``dataRepresentation``
         struct Nonce: ContiguousBytes, Sequence {
-            /// The public nonce data.
+            /// The opaque 132-byte `secp256k1_musig_pubnonce` struct bytes.
+            ///
+            /// Internal-visibility storage; external callers use ``dataRepresentation`` for
+            /// the 66-byte stable wire format.
             let pubnonce: Data
 
-            /// Creates a public nonce from internal 132-byte representation.
+            /// Creates a public nonce from the internal 132-byte representation.
             ///
-            /// This initializer is used internally by nonce generation.
+            /// Internal-visibility constructor used by nonce generation and aggregation.
             ///
-            /// - Parameter pubnonce: The internal public nonce data.
+            /// - Parameter pubnonce: The 132-byte opaque `secp256k1_musig_pubnonce` buffer.
             init(pubnonce: Data) {
                 self.pubnonce = pubnonce
             }
 
             /// Creates a public nonce from a 66-byte serialized representation.
             ///
-            /// This initializer parses a serialized public nonce using the BIP-327 format.
+            /// Parses the BIP-327 wire format via `secp256k1_musig_pubnonce_parse`.
             ///
             /// - Parameter dataRepresentation: A 66-byte serialized public nonce.
-            /// - Throws: An error if the data is invalid or parsing fails.
+            /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the byte count is
+            ///   wrong or parsing fails.
             public init<D: ContiguousBytes>(dataRepresentation: D) throws {
                 let context = P256K.Context.rawRepresentation
                 var nonce = secp256k1_musig_pubnonce()
@@ -72,7 +113,11 @@ public import Foundation
 
             /// Provides access to the raw bytes of the public nonce.
             ///
-            /// - Parameter body: A closure that takes an `UnsafeRawBufferPointer` and returns a value.
+            /// Note this exposes the **132-byte internal struct**, not the 66-byte wire
+            /// format; use ``dataRepresentation`` for the serialized form.
+            ///
+            /// - Parameter body: A closure that takes an `UnsafeRawBufferPointer` and
+            ///   returns a value.
             /// - Returns: The value returned by the closure.
             public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
                 try pubnonce.withUnsafeBytes(body)
@@ -80,12 +125,16 @@ public import Foundation
 
             /// Returns an iterator over the bytes of the public nonce.
             ///
+            /// Iterates over the **132-byte internal struct bytes**, not the 66-byte wire
+            /// format.
+            ///
             /// - Returns: An iterator for the public nonce data.
             public func makeIterator() -> Data.Iterator {
                 pubnonce.makeIterator()
             }
 
-            /// A 66-byte data representation of the public nonce in BIP-327 wire format.
+            /// A 66-byte data representation of the public nonce in BIP-327 wire format,
+            /// produced by `secp256k1_musig_pubnonce_serialize`.
             public var dataRepresentation: Data {
                 let context = P256K.Context.rawRepresentation
                 var nonce = secp256k1_musig_pubnonce()

--- a/Sources/Shared/Schnorr/Schnorr+PrivateKey.swift
+++ b/Sources/Shared/Schnorr/Schnorr+PrivateKey.swift
@@ -20,45 +20,99 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr {
-        /// secp256k1 BIP-340 Schnorr private key for signing messages with ``SchnorrSignature`` and for deriving the x-only public key used in verification.
+        /// secp256k1
+        /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr
+        /// private key for signing messages with ``SchnorrSignature`` and for deriving the
+        /// x-only public key used in verification.
         ///
-        /// Schnorr signatures use `secp256k1_schnorrsig_sign_custom` with the BIP-340 nonce function
-        /// (`secp256k1_nonce_function_bip340`). Unlike ECDSA, signing takes a 32-byte auxiliary
-        /// randomness input that is mixed into the nonce for protection against fault attacks;
-        /// the default ``signature(for:)-7p2ne`` overload supplies fresh random bytes automatically.
+        /// ## Overview
+        ///
+        /// Schnorr signatures use `secp256k1_schnorrsig_sign_custom` with the BIP-340 nonce
+        /// function (`secp256k1_nonce_function_bip340`), both declared in
+        /// [`Vendor/secp256k1/include/secp256k1_schnorrsig.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_schnorrsig.h).
+        /// Unlike ECDSA, signing takes a 32-byte auxiliary randomness input that is mixed
+        /// into the nonce for protection against fault attacks; the default
+        /// `signature(for:)` overloads supply fresh random bytes automatically via
+        /// `SecureBytes`.
         ///
         /// Verification uses x-only public keys (``xonly``), not full compressed keys. The
-        /// ``publicKey`` property returns the full ``PublicKey`` for contexts that require it.
+        /// ``publicKey`` property returns the full ``PublicKey`` for contexts that require
+        /// it (key aggregation, Taproot key-path spending).
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init()``
+        /// - ``init(dataRepresentation:)``
+        ///
+        /// ### Inspection
+        /// - ``publicKey``
+        /// - ``xonly``
+        /// - ``dataRepresentation``
+        /// - ``negation``
         struct PrivateKey: Equatable {
-            /// The internal backing key implementation.
+            /// The internal `PrivateKeyImplementation` backing this Schnorr signing key.
+            ///
+            /// Kept `private` — the backing type wraps the 32-byte secret scalar in
+            /// `SecureBytes`-style zeroizing storage; consumers interact only through the
+            /// public API surface.
             private let baseKey: PrivateKeyImplementation
 
             /// The raw 32-byte secret key bytes as `SecureBytes`.
+            ///
+            /// Internal-visibility accessor used by Swift-side Schnorr signing helpers.
+            /// External callers use ``dataRepresentation`` for a `Data` copy.
             var key: SecureBytes {
                 baseKey.key
             }
 
-            /// The full secp256k1 public key derived from this private key, in uncompressed form (65 bytes).
+            /// The full secp256k1 public key derived from this private key, in uncompressed
+            /// form (65 bytes).
+            ///
+            /// Returned as a full ``PublicKey`` rather than an x-only key because some
+            /// downstream operations (key aggregation, tweak addition on the full point)
+            /// need both coordinates. Use ``xonly`` instead for direct BIP-340 verification.
             public var publicKey: PublicKey {
                 PublicKey(baseKey: baseKey.publicKey)
             }
 
-            /// The 32-byte x-only public key (X coordinate only) for verifying BIP-340 Schnorr signatures created with this key.
+            /// The 32-byte x-only public key (X coordinate only) for verifying BIP-340
+            /// Schnorr signatures created with this key.
+            ///
+            /// This is the canonical external identifier for a Schnorr signer — it's what a
+            /// BIP-340 verifier consumes and what Taproot outputs commit to.
             public var xonly: XonlyKey {
                 XonlyKey(baseKey: baseKey.publicKey.xonly)
             }
 
-            /// The raw 32-byte secret key as `Data`. Keep this value confidential; disclosure allows anyone to sign on your behalf.
+            /// The raw 32-byte secret key as `Data`. Keep this value confidential;
+            /// disclosure allows anyone to sign on your behalf.
+            ///
+            /// The bytes are zeroed when the backing `PrivateKeyImplementation` is
+            /// deallocated, but **copies made through this accessor are not**: any `Data`
+            /// produced here escapes the zeroization scope and must be handled by the
+            /// caller.
             public var dataRepresentation: Data {
                 baseKey.dataRepresentation
             }
 
-            /// A new ``PrivateKey`` whose secret scalar is the additive inverse modulo the secp256k1 curve order, produced by `secp256k1_ec_seckey_negate`.
+            /// A new ``PrivateKey`` whose secret scalar is the additive inverse modulo the
+            /// secp256k1 curve order, produced by `secp256k1_ec_seckey_negate`.
+            ///
+            /// Useful in BIP-340 when the signing key must represent the even-Y
+            /// x-only public key: if ``xonly``'s parity is odd, the signer negates the
+            /// secret scalar before signing so the effective public key has even Y.
             public var negation: Self {
                 Self(baseKey: baseKey.negation)
             }
 
             /// Creates a private key from a validated backing implementation.
+            ///
+            /// Internal-visibility constructor used when the backing implementation has
+            /// already been validated (e.g. by ``negation``); consumers use ``init()`` or
+            /// ``init(dataRepresentation:)`` instead.
+            ///
+            /// - Parameter baseKey: A validated `PrivateKeyImplementation`.
             init(baseKey: PrivateKeyImplementation) {
                 self.baseKey = baseKey
             }

--- a/Sources/Shared/Schnorr/Schnorr+PublicKey.swift
+++ b/Sources/Shared/Schnorr/Schnorr+PublicKey.swift
@@ -20,36 +20,80 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr {
-        /// secp256k1 BIP-340 Schnorr public key in compressed or uncompressed form, from which the x-only key used for signature verification is derived via the ``xonly`` property.
+        /// secp256k1
+        /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr
+        /// public key in compressed or uncompressed form, from which the x-only key used
+        /// for signature verification is derived via the ``xonly`` property.
         ///
-        /// For BIP-340 Schnorr signature verification, use the ``xonly`` property of this key.
-        /// The full ``PublicKey`` is provided for contexts that require the complete curve point,
-        /// such as key aggregation or Taproot key-path spending.
+        /// ## Overview
+        ///
+        /// For BIP-340 Schnorr signature verification, use the ``xonly`` property of this
+        /// key. The full ``PublicKey`` is provided for contexts that require the complete
+        /// curve point, such as key aggregation (``P256K/MuSig/aggregate(_:)``) or
+        /// [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)
+        /// Taproot key-path spending.
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init(xonlyKey:)``
+        /// - ``init(dataRepresentation:format:)``
+        ///
+        /// ### Serialized Forms
+        /// - ``dataRepresentation``
+        /// - ``format``
+        /// - ``xonly``
         struct PublicKey {
-            /// The internal backing public key implementation.
+            /// The internal `PublicKeyImplementation` backing this Schnorr public key.
+            ///
+            /// Kept `internal` — the backing type wraps the 64-byte upstream
+            /// `secp256k1_pubkey` struct plus the serialization format; consumers never see
+            /// the raw C handle through the public API.
             let baseKey: PublicKeyImplementation
 
             /// The serialized public key bytes in the key's ``format``.
+            ///
+            /// Internal-visibility accessor used by Swift-side Schnorr verify helpers;
+            /// external callers use ``dataRepresentation`` for the `Data` form.
             var bytes: [UInt8] {
                 baseKey.bytes
             }
 
-            /// The serialization format of this public key: `.compressed` (33 bytes) or `.uncompressed` (65 bytes).
+            /// The serialization format of this public key: `.compressed` (33 bytes) or
+            /// `.uncompressed` (65 bytes).
+            ///
+            /// Inherited from the `format:` argument at construction time. Both forms
+            /// contain the same underlying `(x, y)` point; pick whichever the downstream
+            /// wire format expects.
             public var format: P256K.Format {
                 baseKey.format
             }
 
             /// The serialized public key bytes as `Data`, in the key's ``format``.
+            ///
+            /// Suitable for transmission and persistence. Most Bitcoin/Taproot workflows
+            /// consume the x-only form instead — use ``xonly`` in that case.
             public var dataRepresentation: Data {
                 baseKey.dataRepresentation
             }
 
-            /// The 32-byte x-only public key (X coordinate only) derived from this key for use in BIP-340 Schnorr signature verification.
+            /// The 32-byte x-only public key (X coordinate only) derived from this key for
+            /// use in BIP-340 Schnorr signature verification.
+            ///
+            /// Computed on every access via `secp256k1_xonly_pubkey_from_pubkey`. The
+            /// returned ``XonlyKey`` carries the original Y-parity in ``XonlyKey/parity``
+            /// so callers can reconstruct the full point when needed.
             public var xonly: XonlyKey {
                 XonlyKey(baseKey: baseKey.xonly)
             }
 
             /// Creates a public key from a validated backing implementation.
+            ///
+            /// Internal-visibility constructor used by factory methods that have already
+            /// validated the backing implementation; consumers use the public initializers
+            /// below.
+            ///
+            /// - Parameter baseKey: A validated `PublicKeyImplementation`.
             init(baseKey: PublicKeyImplementation) {
                 self.baseKey = baseKey
             }

--- a/Sources/Shared/Schnorr/Schnorr+Signature.swift
+++ b/Sources/Shared/Schnorr/Schnorr+Signature.swift
@@ -22,13 +22,34 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr {
-        /// 64-byte BIP-340 Schnorr signature over the secp256k1 elliptic curve, produced by `secp256k1_schnorrsig_sign_custom` and verified by `secp256k1_schnorrsig_verify`.
+        /// 64-byte
+        /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr
+        /// signature over the secp256k1 elliptic curve, produced by
+        /// `secp256k1_schnorrsig_sign_custom` and verified by `secp256k1_schnorrsig_verify`
+        /// (both declared in
+        /// [`Vendor/secp256k1/include/secp256k1_schnorrsig.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_schnorrsig.h)).
         ///
-        /// BIP-340 Schnorr signatures always have a fixed 64-byte encoding: the 32-byte `R.x`
-        /// coordinate followed by 32-byte scalar `s`. There is no DER encoding or alternative
-        /// format. Unlike ECDSA, Schnorr signatures have a unique representation.
+        /// ## Overview
+        ///
+        /// BIP-340 Schnorr signatures always have a fixed 64-byte encoding: the 32-byte
+        /// `R.x` coordinate of the nonce point followed by the 32-byte scalar `s`. There is
+        /// no DER encoding or alternative format. Unlike ECDSA, Schnorr signatures have a
+        /// **unique** representation for a given `(message, key, nonce)` triple — there is
+        /// no `(r, ±s)` symmetry to normalize.
+        ///
+        /// ## Topics
+        ///
+        /// ### Construction
+        /// - ``init(dataRepresentation:)``
+        ///
+        /// ### Serialization
+        /// - ``dataRepresentation``
         struct SchnorrSignature: ContiguousBytes, DataSignature {
             /// The 64-byte BIP-340 Schnorr signature (`R.x || s` in big-endian).
+            ///
+            /// Stable wire format suitable for Bitcoin Taproot witnesses, Nostr events, and
+            /// any other context consuming BIP-340 signatures. The two 32-byte halves are
+            /// the big-endian X-coordinate of the nonce point `R` and the scalar `s`.
             public var dataRepresentation: Data
 
             /// Creates a ``SchnorrSignature`` from a 64-byte raw representation.

--- a/Sources/Shared/Schnorr/Schnorr+Tweak.swift
+++ b/Sources/Shared/Schnorr/Schnorr+Tweak.swift
@@ -19,11 +19,26 @@ import Foundation
 #if Xcode || ENABLE_MODULE_SCHNORRSIG
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr.PrivateKey {
-        /// Create a new `PrivateKey` by adding tweak to the secret key. When tweaking keys,  implicit
-        /// negations are handled when odd Y coordinates are reached.
-        /// [REF](https://github.com/bitcoin-core/secp256k1/issues/1021#issuecomment-983021759)
-        /// - Parameter tweak: the 32-byte tweak object
-        /// - Returns: tweaked `PrivateKey` object
+        /// Creates a new ``P256K/Schnorr/PrivateKey`` by applying a BIP-341 Taproot x-only
+        /// tweak to the secret scalar via `secp256k1_keypair_xonly_tweak_add` (declared in
+        /// [`Vendor/secp256k1/include/secp256k1_extrakeys.h`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_extrakeys.h)).
+        ///
+        /// When the x-only representation of the current key has odd Y, the upstream keypair
+        /// helper implicitly negates the secret scalar before applying the tweak so the
+        /// resulting keypair has even Y (the canonical BIP-340 form). See upstream discussion
+        /// at [bitcoin-core/secp256k1#1021](https://github.com/bitcoin-core/secp256k1/issues/1021#issuecomment-983021759).
+        ///
+        /// This is the signing-side companion to ``P256K/Schnorr/XonlyKey/add(_:)``; applying
+        /// the same tweak to both forms yields a valid `(sk', xonly')` pair for
+        /// [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)
+        /// Taproot key-path spending.
+        ///
+        /// - Parameter tweak: A 32-byte tweak scalar (typically the output of a Taproot
+        ///   `TapTweak` tagged hash).
+        /// - Returns: A new ``P256K/Schnorr/PrivateKey`` whose x-only public key is the
+        ///   Taproot-tweaked form of the original.
+        /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid or
+        ///   any upstream step fails.
         func add(_ tweak: [UInt8]) throws -> Self {
             let context = P256K.Context.rawRepresentation
             var keypair = secp256k1_keypair()
@@ -44,11 +59,23 @@ import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr.XonlyKey {
-        /// Create a new `XonlyKey` by adding tweak to the x-only public key.
-        /// - Parameters:
-        ///   - tweak: the 32-byte tweak object
-        ///   - format: the format of the tweaked `XonlyKey` object
-        /// - Returns: tweaked `PublicKey` object
+        /// Creates a new ``P256K/Schnorr/XonlyKey`` by applying a BIP-341 Taproot tweak to
+        /// the x-only public key via `secp256k1_xonly_pubkey_tweak_add` and verifies the
+        /// result with `secp256k1_xonly_pubkey_tweak_add_check`.
+        ///
+        /// This is the verifier-side companion to
+        /// ``P256K/Schnorr/PrivateKey/add(_:)`` — the same 32-byte tweak applied to both a
+        /// private key and its x-only public key yields a valid `(sk', xonly')` pair for
+        /// Taproot key-path spending. The verification check at the end catches
+        /// inconsistent tweak + parity combinations that would otherwise produce a
+        /// never-verifying output key.
+        ///
+        /// - Parameter tweak: A 32-byte tweak scalar (typically the output of a Taproot
+        ///   `TapTweak` tagged hash).
+        /// - Returns: A new ``P256K/Schnorr/XonlyKey`` equal to the Taproot-tweaked
+        ///   x-only public key.
+        /// - Throws: ``secp256k1Error/underlyingCryptoError`` if the tweak is invalid, the
+        ///   result is the point at infinity, or the consistency check fails.
         func add(_ tweak: [UInt8]) throws -> Self {
             let context = P256K.Context.rawRepresentation
             var pubKey = secp256k1_pubkey()

--- a/Sources/Shared/Schnorr/Schnorr+XonlyKey.swift
+++ b/Sources/Shared/Schnorr/Schnorr+XonlyKey.swift
@@ -20,37 +20,85 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K.Schnorr {
-        /// The corresponding x-only public key for the secp256k1 curve.
+        /// The corresponding x-only public key for the secp256k1 curve, as defined by
+        /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki).
+        ///
+        /// ## Overview
+        ///
+        /// X-only keys drop the Y-coordinate parity bit from the 33-byte compressed
+        /// encoding, matching the representation BIP-340 verifiers consume directly. The
+        /// 1-bit parity is preserved separately as ``parity`` so Taproot tweak verification
+        /// can reconstruct the full `(x, y)` point.
+        ///
+        /// ## Topics
+        ///
+        /// ### Inspection
+        /// - ``bytes``
+        /// - ``parity``
+        /// - ``cache``
+        ///
+        /// ### Construction
+        /// - ``init(dataRepresentation:keyParity:cache:)``
         struct XonlyKey: Equatable {
-            /// Generated secp256k1 x-only public key.
+            /// The internal `XonlyKeyImplementation` backing this x-only key.
+            ///
+            /// Kept `private` — the backing type is an internal convenience over the
+            /// upstream `secp256k1_xonly_pubkey` struct; consumers never see or manipulate
+            /// it directly.
             private let baseKey: XonlyKeyImplementation
 
-            /// The secp256k1 x-only public key object.
+            /// The 32-byte X coordinate of this x-only public key.
+            ///
+            /// Stable across libsecp256k1 versions — safe to persist as a BIP-340-style
+            /// key identifier. Pair with ``parity`` if the full `(x, y)` point must be
+            /// reconstructed downstream (e.g. for Taproot tweak verification).
             public var bytes: [UInt8] {
                 baseKey.bytes
             }
 
-            /// Schnorr x-only public key parity is implicitly even, therefore this always returns `false`.
+            /// The Y-coordinate parity of the underlying secp256k1 public key.
+            ///
+            /// `false` = even Y (canonical BIP-340 form), `true` = odd Y. BIP-340 verifiers
+            /// operate against the even-Y representative, so the parity bit is tracked
+            /// separately and consulted during BIP-341 Taproot tweak verification
+            /// (`secp256k1_xonly_pubkey_tweak_add_check`).
             public var parity: Bool {
                 baseKey.keyParity.boolValue
             }
 
-            /// The cache of information about public key aggregation.
+            /// Cached `secp256k1_pubkey` bytes associated with this x-only key, avoiding
+            /// re-derivation on each operation that needs the full curve point.
+            ///
+            /// > Important: These bytes are the opaque upstream `secp256k1_pubkey` struct
+            /// > and are **not** a stable serialization format across libsecp256k1
+            /// > versions. Treat as a within-process session token; use
+            /// > ``P256K/Schnorr/PublicKey/dataRepresentation`` for persistence.
             public var cache: Data {
                 Data(baseKey.cache)
             }
 
-            /// Generates a secp256k1 x-only public key.
+            /// Creates an x-only public key from a validated backing implementation.
             ///
-            /// - Parameter baseKey: Generated secp256k1 x-only public key.
+            /// Internal-visibility constructor used by ``P256K/Schnorr/PublicKey/xonly`` and
+            /// related accessors; consumers use the public initializer below.
+            ///
+            /// - Parameter baseKey: A validated `XonlyKeyImplementation`.
             init(baseKey: XonlyKeyImplementation) {
                 self.baseKey = baseKey
             }
 
-            /// Generates a secp256k1 x-only public key from a raw representation.
+            /// Creates an x-only public key from a 32-byte X-coordinate, parity bit, and
+            /// optional pre-computed full-pubkey cache.
             ///
-            /// - Parameter data: A data representation of the x-only public key.
-            /// - Parameter keyParity: The key parity as an `Int32`.
+            /// Useful when reconstructing from persisted state (e.g. a Taproot output-key
+            /// identifier and its parity stored in a wallet database).
+            ///
+            /// - Parameter data: The 32-byte X coordinate of the x-only public key.
+            /// - Parameter keyParity: The Y-coordinate parity as an `Int32`: `0` = even,
+            ///   `1` = odd.
+            /// - Parameter cache: Optional pre-computed `secp256k1_pubkey` bytes associated
+            ///   with the x-only key; pass an empty array to have the backing
+            ///   implementation recompute the full pubkey on demand.
             public init<D: ContiguousBytes>(dataRepresentation data: D, keyParity: Int32 = 0, cache: [UInt8] = []) {
                 self.baseKey = XonlyKeyImplementation(dataRepresentation: data, keyParity: keyParity, cache: cache)
             }

--- a/Sources/Shared/Schnorr/Schnorr.swift
+++ b/Sources/Shared/Schnorr/Schnorr.swift
@@ -20,13 +20,59 @@ import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public extension P256K {
-        /// BIP-340 Schnorr signatures over secp256k1: sign with ``PrivateKey``, verify against ``XonlyKey``, using a fixed 64-byte ``SchnorrSignature`` encoding.
+        /// [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr
+        /// signatures over secp256k1: sign with ``PrivateKey``, verify against ``XonlyKey``,
+        /// using a fixed 64-byte ``SchnorrSignature`` encoding.
         ///
-        /// All signing operations use `secp256k1_schnorrsig_sign_custom` with
-        /// `secp256k1_nonce_function_bip340`. Verification uses `secp256k1_schnorrsig_verify`
-        /// against the 32-byte x-only public key, not the full compressed key.
+        /// ## Overview
+        ///
+        /// BIP-340 Schnorr signatures are used by Bitcoin Taproot
+        /// ([BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki), activated
+        /// at block 709632 in November 2021) and by Nostr for event signing. Compared to ECDSA,
+        /// Schnorr signatures are **linear** — they combine additively, which is what makes
+        /// MuSig2 aggregation
+        /// ([BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)) possible
+        /// — and verify against a **32-byte x-only** public key instead of the 33-byte
+        /// compressed form ECDSA requires.
+        ///
+        /// All signing operations call `secp256k1_schnorrsig_sign_custom` (declared in
+        /// `Vendor/secp256k1/include/secp256k1_schnorrsig.h`) with the default BIP-340 nonce
+        /// function `secp256k1_nonce_function_bip340`. Verification uses
+        /// `secp256k1_schnorrsig_verify` against the x-only public key.
+        ///
+        /// ### Nonce Generation
+        ///
+        /// BIP-340 uses a deterministic nonce derived from the private key and message hash via
+        /// tagged SHA-256 (`BIP0340/nonce`). Unlike ECDSA's
+        /// [RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979) nonce, the BIP-340 scheme
+        /// also mixes an auxiliary random value if one is provided, which strengthens resistance
+        /// to fault-injection attacks on the signing device. The swift-secp256k1 wrapper uses
+        /// the upstream default auxiliary randomness drawn from the Swift-side RNG.
+        ///
+        /// ### X-Only Keys
+        ///
+        /// Verification uses the 32-byte X-coordinate of the public key rather than the full
+        /// 33-byte compressed encoding. BIP-340 defines the "implicit Y" to be the even
+        /// Y-coordinate, which saves one byte on the wire and simplifies the verification
+        /// equation. See ``XonlyKey`` for conversion to/from the full public-key forms.
+        ///
+        /// ## Topics
+        ///
+        /// ### Key Types
+        /// - ``PrivateKey``
+        /// - ``PublicKey``
+        /// - ``XonlyKey``
+        /// - ``SecureNonce``
+        ///
+        /// ### Signing Primitives
+        /// - ``Nonce``
+        /// - ``SchnorrSignature``
         enum Schnorr {
             /// The fixed byte length of a BIP-340 Schnorr signature: 64 bytes (`R.x || s`).
+            ///
+            /// The encoding is the concatenation of the 32-byte X-coordinate of the ephemeral
+            /// nonce point `R` and the 32-byte scalar `s`. This is a stable wire format; safe
+            /// to persist and cross process boundaries.
             ///
             /// [BIP340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#abstract)
             @inlinable static var signatureByteCount: Int {
@@ -35,14 +81,23 @@ import Foundation
 
             /// The fixed byte length of a BIP-340 x-only public key: 32 bytes (X coordinate only).
             ///
+            /// Compare to ``P256K/Format/compressed`` (33 bytes, includes parity prefix) and
+            /// ``P256K/Format/uncompressed`` (65 bytes, includes both `(x, y)`). The x-only
+            /// form is the canonical Taproot / Nostr identifier and the one BIP-340 verifiers
+            /// consume directly.
+            ///
             /// [BIP340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#abstract)
             @inlinable static var xonlyByteCount: Int {
                 32
             }
 
-            /// Tuple representation of ``SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC``
+            /// Tuple representation of `SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC`.
             ///
-            /// Only used at initialization and has no other function than making sure the object is initialized.
+            /// This 4-byte magic value (`0xDA6FB38C`) is written into the upstream
+            /// `secp256k1_schnorrsig_extraparams.magic` field to signal that the struct has
+            /// been initialized to a known layout. It is used only at initialization time and
+            /// has no cryptographic role. Pre-computed as a tuple so the swift-side ABI match
+            /// to the upstream C struct is zero-overhead.
             ///
             /// [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_schnorrsig.h#L88)
             @inlinable static var magic: (UInt8, UInt8, UInt8, UInt8) {

--- a/Sources/Shared/UInt256/UInt256+Arithmetic.swift
+++ b/Sources/Shared/UInt256/UInt256+Arithmetic.swift
@@ -8,6 +8,9 @@
 //  See the accompanying file LICENSE for information
 //
 
+// `BinaryInteger` conformance for `UInt256`. Operator docs inherit from the Swift
+// standard library; see `UInt256` for the two-limb contract and timing caveat.
+
 #if Xcode || ENABLE_UINT256
 
     // MARK: - BinaryInteger

--- a/Sources/Shared/UInt256/UInt256+FixedWidthInteger.swift
+++ b/Sources/Shared/UInt256/UInt256+FixedWidthInteger.swift
@@ -8,6 +8,9 @@
 //  See the accompanying file LICENSE for information
 //
 
+// `FixedWidthInteger` + `UnsignedInteger` conformance for `UInt256`. Operator docs
+// inherit from the Swift standard library; see `UInt256` for the two-limb contract.
+
 #if Xcode || ENABLE_UINT256
 
     // MARK: - FixedWidthInteger

--- a/Sources/Shared/UInt256/UInt256+Modular.swift
+++ b/Sources/Shared/UInt256/UInt256+Modular.swift
@@ -8,6 +8,9 @@
 //  See the accompanying file LICENSE for information
 //
 
+// Modular arithmetic helpers (`addMod`, `mulMod`) for `UInt256`. See `UInt256` for the
+// timing caveat; these helpers are not constant-time and must not hold secret scalars.
+
 #if Xcode || ENABLE_UINT256
 
     // MARK: - Modular arithmetic
@@ -16,7 +19,14 @@
     public extension UInt256 {
         /// Returns `(self + other) % modulus`.
         ///
-        /// - Requires: `modulus >= 2`.
+        /// Uses `addingReportingOverflow` to detect the 257-bit intermediate, then reduces
+        /// modulo `modulus` via `dividingFullWidth` when overflow occurs or via a simple
+        /// compare-and-subtract when it doesn't.
+        ///
+        /// - Parameter other: The value to add.
+        /// - Parameter modulus: The modulus (must be ≥ 2).
+        /// - Returns: `(self + other) mod modulus`.
+        /// - Precondition: `modulus >= 2`.
         @inlinable
         func addMod(_ other: UInt256, modulus: UInt256) -> UInt256 {
             precondition(modulus >= 2, "Modulus must be ≥ 2")
@@ -29,7 +39,16 @@
 
         /// Returns `(self * other) % modulus`.
         ///
-        /// - Requires: `modulus != 0`, `self < modulus`, `other < modulus`.
+        /// Computes the full 512-bit intermediate via `multipliedFullWidth(by:)` and
+        /// reduces with a single `dividingFullWidth` call. Assumes both operands are
+        /// already reduced modulo `modulus` (`self < modulus` and `other < modulus`) so
+        /// the intermediate does not overflow the 512-bit `(high, low)` tuple when
+        /// `modulus` is near `2^256`.
+        ///
+        /// - Parameter other: The value to multiply.
+        /// - Parameter modulus: The modulus (must be non-zero).
+        /// - Returns: `(self * other) mod modulus`.
+        /// - Precondition: `modulus != 0`, `self < modulus`, `other < modulus`.
         @inlinable
         func mulMod(_ other: UInt256, modulus: UInt256) -> UInt256 {
             precondition(modulus != .zero, "Modulus must be non-zero")
@@ -42,6 +61,12 @@
 
     @available(macOS 15.0, iOS 18.0, macCatalyst 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     extension UInt256 {
+        /// Reinterprets this `UInt256` value as an ``Int256`` with the same bit pattern.
+        ///
+        /// Internal-visibility convenience used by arithmetic helpers that need a signed
+        /// interpretation of the same 256 bits (e.g. `Stride` computations). No data
+        /// conversion occurs; see ``UInt256/init(bitPattern:)`` for the equivalent
+        /// external API.
         @inlinable
         func toInt256() -> Int256 {
             Int256(bitPattern: self)

--- a/Sources/Shared/UInt256/UInt256+Representation.swift
+++ b/Sources/Shared/UInt256/UInt256+Representation.swift
@@ -8,6 +8,9 @@
 //  See the accompanying file LICENSE for information
 //
 
+// `Equatable` / `Hashable` / `Comparable` / `Strideable` / string / `Numeric`
+// conformances for `UInt256` / `Int256`. Docs inherit from the Swift standard library.
+
 #if Xcode || ENABLE_UINT256
 
     public import Foundation

--- a/Sources/Shared/UInt256/UInt256.swift
+++ b/Sources/Shared/UInt256/UInt256.swift
@@ -10,18 +10,58 @@
 
 #if Xcode || ENABLE_UINT256
 
-    /// A 256-bit unsigned integer backed by two `UInt128` limbs, conforming to `FixedWidthInteger`, `BinaryInteger`, and `UnsignedInteger`; used for 256-bit field arithmetic on the secp256k1 curve.
+    /// A 256-bit unsigned integer backed by two `UInt128` limbs, conforming to
+    /// `FixedWidthInteger`, `BinaryInteger`, and `UnsignedInteger`; used for 256-bit field
+    /// arithmetic on the secp256k1 curve.
+    ///
+    /// ## Overview
+    ///
+    /// `UInt256` is the natural Swift representation for a secp256k1 private key scalar or
+    /// field element: both fit in exactly 32 bytes, and both require integer arithmetic
+    /// modulo the curve order `n` or field prime `p`. The implementation uses two
+    /// `Swift.UInt128`
+    /// limbs (low and high) rather than a byte array so that the compiler can emit native
+    /// 128-bit operations on platforms that support them (ARM64 `add`/`adc` pairs on Apple
+    /// Silicon; LLVM-synthesized 128-bit intrinsics on Intel).
+    ///
+    /// > Important: **This type is not a cryptographic scalar class.** It provides generic
+    /// > integer arithmetic. Operations are not constant-time with respect to operand
+    /// > values and must not be used to hold secret scalars in contexts where timing
+    /// > leakage matters. For secret scalar arithmetic, use the upstream libsecp256k1 APIs
+    /// > that operate on `secp256k1_scalar` / `secp256k1_fe` in constant time.
+    ///
+    /// The type is gated behind the `UInt256` trait (or `Xcode` build), requiring Swift 6.1
+    /// with Swift's native `UInt128` type (macOS 15, iOS 18, etc.).
     @available(macOS 15.0, iOS 18.0, macCatalyst 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     @frozen
     public struct UInt256 {
+        /// The low 128 bits of the 256-bit value.
+        ///
+        /// Internal-visibility (`@usableFromInline`) so `@inlinable` arithmetic in
+        /// sibling files can access the limbs directly without forcing a widening of the
+        /// public API surface.
         @usableFromInline var _low: Swift.UInt128
+
+        /// The high 128 bits of the 256-bit value.
+        ///
+        /// Internal-visibility (`@usableFromInline`) so `@inlinable` arithmetic can reach
+        /// the limb directly. Combined with ``_low`` yields `value = _high * 2^128 + _low`.
         @usableFromInline var _high: Swift.UInt128
 
+        /// Creates a `UInt256` with the value `0`.
         @inlinable public init() {
             self._low = 0
             self._high = 0
         }
 
+        /// Creates a `UInt256` from raw low and high `UInt128` limbs.
+        ///
+        /// Internal-visibility constructor used by arithmetic helpers that compute the
+        /// limbs directly; consumers build values via the public literal / integer
+        /// initializers declared in `UInt256+FixedWidthInteger.swift`.
+        ///
+        /// - Parameter _low: The low 128 bits.
+        /// - Parameter _high: The high 128 bits; the final value is `_high * 2^128 + _low`.
         @usableFromInline
         init(_low: Swift.UInt128, _high: Swift.UInt128) {
             self._low = _low
@@ -29,18 +69,48 @@
         }
     }
 
-    /// A 256-bit signed integer backed by a `UInt128` low limb and an `Int128` high limb, conforming to `FixedWidthInteger`, `BinaryInteger`, and `SignedInteger`; the signed counterpart to ``UInt256``.
+    /// A 256-bit signed integer backed by a `UInt128` low limb and an `Int128` high limb,
+    /// conforming to `FixedWidthInteger`, `BinaryInteger`, and `SignedInteger`; the signed
+    /// counterpart to ``UInt256``.
+    ///
+    /// ## Overview
+    ///
+    /// `Int256` is the two's-complement counterpart to ``UInt256`` used where signed
+    /// arithmetic is needed (e.g. certain BIP-32 child-key derivation intermediate steps
+    /// or Miller-Rabin witness computations). The high limb is `Swift.Int128` so the sign
+    /// bit lives in its natural position (bit 255); the low limb remains `UInt128` to keep
+    /// addition / subtraction carry logic uniform with the unsigned type.
+    ///
+    /// > Important: Same caveat as ``UInt256`` — operations are not constant-time and
+    /// > must not be used for secret scalar arithmetic.
     @available(macOS 15.0, iOS 18.0, macCatalyst 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     @frozen
     public struct Int256 {
+        /// The low 128 bits of the 256-bit value (always interpreted as unsigned).
+        ///
+        /// Internal-visibility limb used by `@inlinable` arithmetic. Kept `UInt128` even
+        /// on the signed type so carry propagation from the low limb matches the unsigned
+        /// case.
         @usableFromInline var _low: Swift.UInt128
+
+        /// The high 128 bits of the 256-bit value, including the sign bit at position 255.
+        ///
+        /// Internal-visibility limb. Value is `_high * 2^128 + Int128(bitPattern: _low)`
+        /// under two's-complement semantics.
         @usableFromInline var _high: Swift.Int128
 
+        /// Creates an `Int256` with the value `0`.
         @inlinable public init() {
             self._low = 0
             self._high = 0
         }
 
+        /// Creates an `Int256` from raw low (`UInt128`) and high (`Int128`) limbs.
+        ///
+        /// Internal-visibility constructor used by arithmetic helpers.
+        ///
+        /// - Parameter _low: The low 128 bits (unsigned).
+        /// - Parameter _high: The high 128 bits (signed, containing the sign bit).
         @usableFromInline
         init(_low: Swift.UInt128, _high: Swift.Int128) {
             self._low = _low
@@ -52,6 +122,13 @@
 
     @available(macOS 15.0, iOS 18.0, macCatalyst 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     public extension UInt256 {
+        /// Creates a `UInt256` with the same bit pattern as a signed ``Int256`` value.
+        ///
+        /// Preserves the raw 256 bits verbatim; negative `Int256` values become large
+        /// unsigned values via two's-complement interpretation. Matches the Swift
+        /// standard-library convention (e.g. `UInt64(bitPattern: Int64)`).
+        ///
+        /// - Parameter source: The signed value whose bits are reinterpreted.
         @inlinable
         init(bitPattern source: Int256) {
             self._low = source._low
@@ -61,6 +138,12 @@
 
     @available(macOS 15.0, iOS 18.0, macCatalyst 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     public extension Int256 {
+        /// Creates an `Int256` with the same bit pattern as an unsigned ``UInt256`` value.
+        ///
+        /// Preserves the raw 256 bits verbatim; unsigned values ≥ `2^255` become negative
+        /// `Int256` values via two's-complement interpretation.
+        ///
+        /// - Parameter source: The unsigned value whose bits are reinterpreted.
         @inlinable
         init(bitPattern source: UInt256) {
             self._low = source._low

--- a/Sources/Shared/Utility.swift
+++ b/Sources/Shared/Utility.swift
@@ -17,23 +17,54 @@ public import Foundation
 #endif
 
 public extension ContiguousBytes {
-    /// The raw bytes of this value as a `[UInt8]` array, equivalent to `withUnsafeBytes { Array($0) }`.
+    /// The raw bytes of this value as a `[UInt8]` array, equivalent to
+    /// `withUnsafeBytes { Array($0) }`.
+    ///
+    /// Convenience accessor used throughout swift-secp256k1 to marshal arbitrary
+    /// `ContiguousBytes` conformers (`Data`, `[UInt8]`, `SecureBytes`, etc.) into a byte
+    /// array for passing to upstream C functions that expect `const unsigned char *`.
+    /// The copy is unavoidable when the upstream API requires a guaranteed-contiguous
+    /// buffer with a known length.
     @inlinable var bytes: [UInt8] {
         withUnsafeBytes { bytesPtr in Array(bytesPtr) }
     }
 }
 
 public extension Data {
-    /// Copies up to `MemoryLayout<T>.size` bytes from this `Data` into the raw memory of `value`, used to populate opaque C structs such as `secp256k1_pubkey` and `secp256k1_musig_aggnonce`.
+    /// Copies up to `MemoryLayout<T>.size` bytes from this `Data` into the raw memory of
+    /// `value`, used to populate opaque C structs such as `secp256k1_pubkey` and
+    /// `secp256k1_musig_aggnonce`.
     ///
-    /// - Parameter value: The inout value whose raw bytes are overwritten; only the leading `min(self.count, MemoryLayout<T>.size)` bytes are written.
+    /// Swift-side helper for round-tripping opaque upstream structs through wire formats.
+    /// The upstream C structs are declared as `unsigned char data[N]` arrays, so copying
+    /// their raw bytes into a freshly-zeroed `T` via this helper is safe when the Swift
+    /// `Data` was produced by a matching upstream `*_serialize` call on the same version
+    /// of libsecp256k1.
+    ///
+    /// > Important: These struct layouts are **not stable across libsecp256k1 versions**.
+    /// > Cross-process persistence should use the upstream `*_serialize` / `*_parse`
+    /// > functions exposed by the wrapper types, not the raw struct bytes.
+    ///
+    /// - Parameter value: The inout value whose raw bytes are overwritten; only the
+    ///   leading `min(self.count, MemoryLayout<T>.size)` bytes are written.
     func copyToUnsafeMutableBytes<T>(of value: inout T) {
         _ = Swift.withUnsafeMutableBytes(of: &value) { ptr in
             ptr.copyBytes(from: self.prefix(ptr.count))
         }
     }
 
-    /// The data prefixed with a Bitcoin-style compact-size integer encoding the byte count: 1 byte for lengths 0–252, 3 bytes (`0xfd` + LE16) for 253–65535, 5 bytes (`0xfe` + LE32) for larger, and 9 bytes (`0xff` + LE64) for the full 64-bit range.
+    /// The data prefixed with a Bitcoin-style compact-size integer encoding the byte count.
+    ///
+    /// Compact-size (aka `CompactSize` / `VarInt`) is the variable-length integer encoding
+    /// Bitcoin Core uses for serialized wire formats
+    /// ([`src/serialize.h`](https://github.com/bitcoin/bitcoin/blob/master/src/serialize.h)).
+    /// The encoding is **not** the same as the Protobuf `varint` or SQLite `varint` — it
+    /// uses a fixed prefix byte to indicate width:
+    ///
+    /// - 1 byte for lengths `0–252` (the length byte itself)
+    /// - 3 bytes (`0xfd` + little-endian `UInt16`) for `253–65535`
+    /// - 5 bytes (`0xfe` + little-endian `UInt32`) for `65536–4_294_967_295`
+    /// - 9 bytes (`0xff` + little-endian `UInt64`) for the full 64-bit range
     var compactSizePrefix: Data {
         let size = UInt64(count)
         var prefix = Data()
@@ -60,17 +91,30 @@ public extension Data {
     }
 }
 
-/// An extension for Int32 providing a convenience property.
+/// Convenience coercion for the `Int32` return type used throughout libsecp256k1.
 extension Int32 {
-    /// A property that returns a Bool representation of the Int32 value.
+    /// A `Bool` representation of the `Int32` value: `true` for any non-zero value,
+    /// `false` for `0`.
+    ///
+    /// Used to translate upstream libsecp256k1 return values (which follow the standard
+    /// C convention of `1` for success, `0` for failure) into Swift-native `Bool` for
+    /// `guard` / `if` predicates at call sites.
     var boolValue: Bool {
         Bool(truncating: NSNumber(value: self))
     }
 }
 
-/// An extension for secp256k1_ecdsa_signature providing a convenience property.
+/// Internal-visibility extraction of the opaque byte buffer inside
+/// `secp256k1_ecdsa_signature`.
 extension secp256k1_ecdsa_signature {
-    /// A property that returns the Data representation of the `secp256k1_ecdsa_signature` object.
+    /// A `Data` copy of the opaque 64-byte `data` array inside the upstream
+    /// `secp256k1_ecdsa_signature` struct.
+    ///
+    /// Used only for in-memory comparisons / hashing within the Swift wrapper. The bytes
+    /// are **not** a stable serialization format across libsecp256k1 versions; external
+    /// transmission uses the compact (64-byte) or DER serializations produced by
+    /// `secp256k1_ecdsa_signature_serialize_compact` and
+    /// `secp256k1_ecdsa_signature_serialize_der`.
     var dataValue: Data {
         var mutableSig = self
         return Data(bytes: &mutableSig.data, count: MemoryLayout.size(ofValue: data))
@@ -78,9 +122,16 @@ extension secp256k1_ecdsa_signature {
 }
 
 #if Xcode || ENABLE_MODULE_RECOVERY
-    /// An extension for secp256k1_ecdsa_recoverable_signature providing a convenience property.
+    /// Internal-visibility extraction of the opaque byte buffer inside
+    /// `secp256k1_ecdsa_recoverable_signature`.
     extension secp256k1_ecdsa_recoverable_signature {
-        /// A property that returns the Data representation of the `secp256k1_ecdsa_recoverable_signature` object.
+        /// A `Data` copy of the opaque 65-byte `data` array inside the upstream
+        /// `secp256k1_ecdsa_recoverable_signature` struct.
+        ///
+        /// Used only for in-memory comparisons within the Swift wrapper. Wire-format
+        /// persistence should use
+        /// `secp256k1_ecdsa_recoverable_signature_serialize_compact`, which produces a
+        /// 64-byte compact signature plus a separate recovery-ID byte.
         var dataValue: Data {
             var mutableSig = self
             return Data(bytes: &mutableSig.data, count: MemoryLayout.size(ofValue: data))
@@ -90,7 +141,12 @@ extension secp256k1_ecdsa_signature {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public extension String {
-    /// Creates a lowercase hex-encoded string from `bytes`, backed by the `hexString` property on `DataProtocol`.
+    /// Creates a lowercase hex-encoded string from `bytes`, backed by the `hexString`
+    /// property on `DataProtocol`.
+    ///
+    /// Each input byte becomes exactly two lowercase hexadecimal characters; no prefix
+    /// (e.g. `0x`) and no separators are added. Useful for displaying fingerprints, key
+    /// fingerprints, and Bitcoin txids / block hashes.
     ///
     /// - Parameter bytes: The bytes to encode as a hexadecimal string.
     init<T: DataProtocol>(bytes: T) {
@@ -100,7 +156,14 @@ public extension String {
 
     /// The bytes decoded from this hex string, lowercased before decoding.
     ///
-    /// - Throws: `ByteHexEncodingErrors.invalidHexString` if the string contains non-hex characters; `ByteHexEncodingErrors.invalidHexValue` if the string has an odd length.
+    /// Expects a string of even length containing only `[0-9a-fA-F]`. The lowercasing
+    /// step is defensive — the underlying decoder is case-sensitive on its lowercase
+    /// path — and means the input is rejected even if it contains ambiguous characters
+    /// like non-ASCII digits.
+    ///
+    /// - Throws: `ByteHexEncodingErrors.invalidHexString` if the string contains non-hex
+    ///   characters; `ByteHexEncodingErrors.invalidHexValue` if the string has an odd
+    ///   length.
     var bytes: [UInt8] {
         get throws {
             // The `BytesUtil.swift` Array extension expects lowercase strings.
@@ -109,17 +172,28 @@ public extension String {
     }
 }
 
-/// A utility class or struct to contain the static function
+/// Internal-visibility helper for the common pattern of passing an array of
+/// pointer-to-`T` values to a C variadic / array-of-pointers parameter.
+///
+/// Used where upstream libsecp256k1 functions take `const T * const *` (e.g.
+/// `secp256k1_ec_pubkey_combine` accepts `const secp256k1_pubkey * const * ins`). The
+/// helper allocates, writes, hands the pointer array to the caller's closure, and
+/// deallocates after the closure returns.
 enum PointerArrayUtility {
-    /// Executes a closure with an array of `UnsafePointer<T>?`.
+    /// Executes `body` with an array of `UnsafePointer<T>?` wrapping each element of
+    /// `collection`, allocating fresh storage per element and deallocating after the
+    /// closure returns.
     ///
-    /// This method automatically manages memory allocation and deallocation
-    /// for each pointer.
+    /// The `inout` parameter to `body` is a live pointer array safe to pass directly
+    /// into an upstream C function that accepts `const T * const *`. The pointers are
+    /// stable for the duration of the closure; **do not** let them escape the closure
+    /// scope — the `defer` block deallocates them on return.
     ///
     /// - Parameters:
     ///   - collection: An array of `T` objects to be converted to `UnsafePointer<T>?`.
-    ///   - body: A closure that receives an array of `UnsafePointer<T>?` and returns a result of type `Result`.
-    /// - Returns: The result of the closure of type `Result`.
+    ///   - body: A closure that receives an array of `UnsafePointer<T>?` and returns a
+    ///     result of type `Result`.
+    /// - Returns: The value produced by `body`.
     static func withUnsafePointerArray<T, Result>(
         _ collection: [T],
         _ body: (inout [UnsafePointer<T>?]) -> Result

--- a/Sources/ZKP/ZKP.docc/ChoosingP256KvsZKP.md
+++ b/Sources/ZKP/ZKP.docc/ChoosingP256KvsZKP.md
@@ -1,0 +1,85 @@
+# Choosing Between P256K and ZKP
+
+@Metadata {
+    @TitleHeading("Explanation")
+}
+
+When to reach for ``P256K`` (vanilla secp256k1 for Bitcoin, Lightning, Nostr) versus ``ZKP`` (Blockstream's `secp256k1-zkp` fork for confidential transactions, adaptor signatures, and zero-knowledge proofs).
+
+## Overview
+
+The package ships two products that wrap two distinct C libraries: `P256K` wraps upstream [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1), while `ZKP` wraps the [BlockstreamResearch/secp256k1-zkp](https://github.com/BlockstreamResearch/secp256k1-zkp) fork of upstream [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1). The fork adds zero-knowledge proof primitives that the upstream library deliberately scopes out: range proofs (*Confidential Transactions*), surjection proofs (asset-swap unlinkability), ECDSA and BIP-340 adaptor signatures (atomic swaps and scriptless scripts), MuSig2 half-aggregation, and Bulletproofs++ (`bppp` trait). The decision between them is driven by which **set of opt-in traits** you need.
+
+### The two products
+
+Two trait tables live in `Package.swift` (see [the full declaration on GitHub](https://github.com/21-DOT-DEV/swift-secp256k1/blob/main/Package.swift)):
+
+- **`moduleDefines`** — six traits that gate upstream secp256k1 modules: `ecdh`, `ellswift`, `musig`, `recovery`, `schnorrsig`, and `uint256`. Each one maps to an `ENABLE_MODULE_*` define on the C compilation.
+- **`zkpModuleDefines`** — eight ZKP-only traits that gate the Blockstream fork's additional modules. The first seven are `bppp`, `ecdsaAdaptor`, `ecdsaS2C`, `generator`, `rangeproof`, `schnorrsigHalfagg`, and `surjectionproof`. The eighth trait gates Blockstream's allow-list-ring-signature module (identifier preserved verbatim in the upstream fork's public API; see the `zkpModuleDefines` entry in `Package.swift` and the [BlockstreamResearch/secp256k1-zkp module layout](https://github.com/BlockstreamResearch/secp256k1-zkp)).
+
+Default-enabled traits for `P256K` are `ecdh`, `musig`, `recovery`, and `schnorrsig` (Package.swift `traits:` block). The `zkp` aggregate trait additionally enables every flag in `zkpModuleDefines` plus `ellswift`, mapping cleanly to the Liquid Network's confidential-transaction feature surface.
+
+### When to reach for P256K
+
+`P256K` is the default choice for Bitcoin, Lightning, Nostr, and any other application that uses vanilla secp256k1 cryptography. Concretely:
+
+- **Bitcoin signing**: ECDSA with RFC 6979 deterministic nonces is the legacy script-signature scheme; `P256K.Signing.PrivateKey` produces lower-S-normalized signatures that pass `secp256k1_ecdsa_verify` without further processing.
+- **Taproot signing**: BIP-340 Schnorr signatures (`P256K.Schnorr.PrivateKey`) are the v1 witness program signature scheme defined in [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki). Cite [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) for the signature construction itself.
+- **Multi-signature aggregation**: BIP-327 MuSig2 (`P256K.MuSig`) aggregates N signatures into a single 64-byte Schnorr signature, indistinguishable on-chain from a single-key spend. See [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki).
+- **Nostr events**: NIP-01 signs events with a 32-byte x-only key (BIP-340 Schnorr); the `xonly` accessor on every Schnorr key returns the right shape.
+- **Recoverable signatures**: Bitcoin signed-message workflows ([BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki), [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki)) use recoverable ECDSA (`P256K.Recovery`) so verifiers can recover the public key from the 65-byte `signature || recoveryId` payload alone, eliminating one round trip in address-discovery flows.
+
+The bitcoin-core README at [github.com/bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1) describes the upstream library's stability guarantees and threat model — `P256K` inherits those guarantees.
+
+### When to reach for ZKP
+
+`ZKP` is the right choice when your application needs **zero-knowledge proof primitives** that the upstream library deliberately scopes out. Each ZKP-only trait corresponds to a research result or production protocol:
+
+- **Range proofs** (`rangeproof` trait): The original [Confidential Transactions](https://people.xiph.org/~greg/confidential_values.txt) construction by Greg Maxwell (Bitcoin core developer) — proves that a Pedersen-committed value lies in a specified range without revealing the value itself. The canonical consumer is the [Liquid Network](https://liquid.net/), Blockstream's federated sidechain.
+- **Bulletproofs++** (`bppp` trait): A more efficient range-proof construction by Liu et al. ([eprint/2022/510](https://eprint.iacr.org/2022/510)), reducing proof sizes versus original Bulletproofs while preserving the same security guarantees.
+- **Surjection proofs** (`surjectionproof` trait): Prove that an output asset comes from one of N input assets without revealing which — the privacy backbone of Liquid's confidential-asset transactions.
+- **Adaptor signatures** (`ecdsaAdaptor` trait): The scriptless-script primitive by Andrew Poelstra et al., documented at [github.com/ElementsProject/scriptless-scripts](https://github.com/ElementsProject/scriptless-scripts). Adaptor signatures enable atomic swaps, payment channels with non-script-based payment proofs, and discreet log contracts (DLCs).
+- **MuSig2 half-aggregation** (`schnorrsigHalfagg` trait): Compresses N Schnorr signatures over distinct messages into roughly N/2 + 1 group elements; useful when batch-verifying many independent BIP-340 signatures.
+
+If your application uses any of these primitives — even just one — `import ZKP` rather than `import P256K`. Mixed imports are technically possible but require fully-qualified `P256K.…` lookups to disambiguate the duplicated shared-source types.
+
+### Shared cryptographic surface
+
+`SharedSourcesPlugin` (declared in `Package.swift` as `.plugin(name: "SharedSourcesPlugin", capability: .buildTool())`) compiles every Swift file under `Sources/Shared/` into both `P256K` and `ZKP` builds. This means the entire vanilla cryptographic surface — ``P256K/Signing``, ``P256K/Schnorr``, ``P256K/MuSig``, ``P256K/Recovery``, ``P256K/KeyAgreement``, ``SHA256`` — is identical across the two products. Choosing `ZKP` does **not** sacrifice any vanilla capability; it adds to the surface.
+
+### Stability guarantees
+
+Both products are pre-1.0 — major-version zero per [SemVer 2.0 §4](https://semver.org/#spec-item-4): "Major version zero (`0.y.z`) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable." Pin `exact:` versions in `Package.swift` to avoid surprise migrations. `P256K` is the planned long-term stability surface; `ZKP` tracks Blockstream's `secp256k1-zkp` fork, which itself tracks Bitcoin Core's stability cadence on the shared surface and Blockstream's research cadence on the proof-primitive surface.
+
+### Mixing products
+
+Both products can be imported in the same Swift file — each links its own copy of the underlying C library with disjoint trait flags. The shared Swift types (defined in `Sources/Shared/`) are the same source by identity but live in two distinct module namespaces (`P256K.…` and `ZKP.…`); ambiguous references in mixed-import contexts must be fully qualified. Most applications avoid the friction by picking one product per target:
+
+```swift
+// Bitcoin / Lightning / Nostr stack: vanilla cryptography only.
+import P256K
+
+let signingKey = try P256K.Signing.PrivateKey()
+let signature = signingKey.signature(for: message)
+```
+
+```swift
+// Liquid / Elements stack: range proofs, surjection proofs,
+// adaptor signatures, MuSig2 half-aggregation.
+import ZKP
+
+// All P256K-equivalent APIs are available here too, plus the
+// ZK extensions gated by the `zkp` aggregate trait.
+let signingKey = try P256K.Signing.PrivateKey()
+```
+
+## See Also
+
+- ``P256K``
+- ``ZKP``
+- [bitcoin-core/secp256k1 README](https://github.com/bitcoin-core/secp256k1/blob/master/README.md)
+- [BlockstreamResearch/secp256k1-zkp README](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/README.md)
+- [BIP-340: Schnorr Signatures for secp256k1](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
+- [BIP-327: MuSig2 for BIP-340 Schnorr signatures](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)
+- [BIP-341: Taproot — SegWit version 1 spending rules](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)
+- [Liquid Network](https://liquid.net/)

--- a/Sources/ZKP/ZKP.docc/ZKP.md
+++ b/Sources/ZKP/ZKP.docc/ZKP.md
@@ -4,12 +4,66 @@
     @TitleHeading("Framework")
 }
 
-ZKP provides zero-knowledge proof primitives for the secp256k1 curve, built on the `libsecp256k1-zkp` library.
+Zero-knowledge proof primitives for the secp256k1 curve — adaptor signatures, range proofs, surjection proofs, and MuSig2 half-aggregation — layered on Blockstream's `secp256k1-zkp` fork of `libsecp256k1`.
 
 ## Overview
 
-The ZKP module wraps `libsecp256k1-zkp` with a Swift API for range proofs, surjection proofs, adaptor signatures, and other advanced cryptographic protocols used in confidential transactions and privacy-preserving systems.
+`ZKP` wraps the [BlockstreamResearch/secp256k1-zkp](https://github.com/BlockstreamResearch/secp256k1-zkp) fork of upstream [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1). The fork adds zero-knowledge proof primitives that the upstream library deliberately scopes out: range proofs (*Confidential Transactions*), surjection proofs (asset-swap unlinkability), ECDSA and BIP-340 adaptor signatures (atomic swaps and scriptless scripts), MuSig2 half-aggregation, and Bulletproofs++ (`bppp` trait). Blockstream's [Liquid Network](https://liquid.net/) — the canonical consumer — depends on the fork for its confidential-asset transaction format.
 
-ZKP shares the same core cryptographic types as ``P256K`` (ECDSA, Schnorr, MuSig2, ECDH, key recovery) and extends them with additional zero-knowledge proof capabilities from the Elements/Liquid sidechain project.
+`ZKP` shares the same vanilla cryptographic surface as ``P256K`` via the package's `SharedSourcesPlugin` build-tool plugin: every type in `Sources/Shared/` (ECDSA, BIP-340 Schnorr, BIP-327 MuSig2, ECDH, recoverable signatures, SHA-256, tagged hashes) is compiled into both products. The two products differ only in their underlying C library (`libsecp256k1` vs `libsecp256k1_zkp`) and the set of opt-in traits each enables. Read <doc:ChoosingP256KvsZKP> to decide which product fits your application.
 
-> Note: This module is under active development. Public API will be added in future releases.
+> Note: The ZKP-exclusive zero-knowledge surface is C-only at present — Swift wrappers for range proofs, surjection proofs, adaptor signatures, and MuSig2 half-aggregation will be added incrementally. The shared surface listed below is fully supported today.
+
+## Topics
+
+### Essentials
+
+- <doc:ChoosingP256KvsZKP>
+- ``P256K``
+- ``P256K/Context``
+- ``P256K/Format``
+
+### ECDSA
+
+- ``P256K/Signing``
+- ``P256K/Signing/PrivateKey``
+- ``P256K/Signing/PublicKey``
+- ``P256K/Signing/XonlyKey``
+- ``P256K/Signing/ECDSASignature``
+
+### BIP-340 Schnorr
+
+- ``P256K/Schnorr``
+- ``P256K/Schnorr/PrivateKey``
+- ``P256K/Schnorr/PublicKey``
+- ``P256K/Schnorr/XonlyKey``
+- ``P256K/Schnorr/SchnorrSignature``
+
+### BIP-327 MuSig2
+
+- ``P256K/MuSig``
+- ``P256K/MuSig/PublicKey``
+- ``P256K/MuSig/Nonce``
+
+### Recoverable signatures
+
+- ``P256K/Recovery``
+- ``P256K/Recovery/PrivateKey``
+- ``P256K/Recovery/PublicKey``
+- ``P256K/Recovery/ECDSASignature``
+
+### ECDH key agreement
+
+- ``P256K/KeyAgreement``
+- ``P256K/KeyAgreement/PrivateKey``
+- ``P256K/KeyAgreement/PublicKey``
+- ``SharedSecret``
+
+### Hashing
+
+- ``SHA256``
+- ``HashDigest``
+
+### Errors
+
+- ``secp256k1Error``


### PR DESCRIPTION
- Refresh doc comments across Sources/Shared/ with upstream citations (libsecp256k1/secp256k1-zkp headers, BIPs 32/137/146/322/324/327/340/341/352) and Topics sections on major types
- Update 7 DocC catalog articles; add ChoosingP256KvsZKP
- Swap SHA256 FIPS 180-4 link for RFC 6234 (consistent with existing RFC 6979 citations)
- Add DocC Validation job to apple-builds.yml (generate-documentation --warnings-as-errors)
- Add docc-release.yml to build/upload DocC archives on release
- AGENTS.md: document cross-archive xref gotcha and Snippets/ rationale (SE-0356 scoping vs. dual C-binding products)