### PR TITLE
docs: add DocC links to README examples and create ECDH/Silent Payments guides

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,3 @@
 version: 1
 external_links:
-  documentation: "https://docs.21.dev/documentation/"
+  documentation: "https://docs.21.dev/documentation/p256k/"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ let signature = privateKey.signature(for: messageData)
 print(signature.derRepresentation.base64EncodedString())
 ```
 
+*→ Full API: [docs.21.dev/documentation/p256k/p256k/signing](https://docs.21.dev/documentation/p256k/p256k/signing)*
+
 ### Schnorr
 ```swift
 // Strict BIP340 mode is disabled by default for Schnorr signatures with variable length messages
@@ -162,6 +164,8 @@ var messageDigest = try! "7E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9
 let signature = try! privateKey.signature(message: &messageDigest, auxiliaryRand: &auxRand)
 ```
 
+*→ Full API: [docs.21.dev/documentation/p256k/p256k/schnorr](https://docs.21.dev/documentation/p256k/p256k/schnorr)*
+
 ### Tweak
 
 ```swift
@@ -172,6 +176,8 @@ let tweak = try! "5f0da318c6e02f653a789950e55756ade9f194e1ec228d7f368de1bd821322
 let tweakedPrivateKey = try! privateKey.add(tweak)
 let tweakedPublicKeyKey = try! privateKey.publicKey.add(tweak)
 ```
+
+*→ Full API: [docs.21.dev/documentation/p256k/tweakingkeys](https://docs.21.dev/documentation/p256k/tweakingkeys)*
 
 ### Elliptic Curve Diffie Hellman
 
@@ -185,6 +191,8 @@ let sharedSecret = privateKey.sharedSecretFromKeyAgreement(with: publicKey, form
 // By default, libsecp256k1 hashes the x-coordinate with version information.
 let symmetricKey = SHA256.hash(data: sharedSecret.bytes)
 ```
+
+*→ Full guide: [docs.21.dev/documentation/p256k/ellipticcurvediffiehellman](https://docs.21.dev/documentation/p256k/ellipticcurvediffiehellman)*
 
 ### Silent Payments Scheme
 
@@ -213,6 +221,8 @@ let schnorrPrivate = try! P256K.Schnorr.PrivateKey(dataRepresentation: sharedSec
 let xonlyTweak2 = try! schnorrPrivate.xonly.add(privateSign1.publicKey.xonly.bytes)
 ```
 
+*→ Full guide: [docs.21.dev/documentation/p256k/silentpayments](https://docs.21.dev/documentation/p256k/silentpayments)* — BIP-352 walkthrough with sender derivation, receiver scanning, scan/spend key separation, and tagged-hash specifics.
+
 ### Recovery
 
 ```swift
@@ -229,6 +239,8 @@ let publicKey = P256K.Recovery.PublicKey(messageData, signature: recoverySignatu
 let signature = recoverySignature.normalize
 ```
 
+*→ Full API: [docs.21.dev/documentation/p256k/p256k/recovery](https://docs.21.dev/documentation/p256k/p256k/recovery)*
+
 ### Combine Public Keys
 
 ```swift
@@ -238,6 +250,8 @@ let publicKey = try! P256K.Signing.PrivateKey().publicKey
 // The Combine API arguments are an array of PublicKey objects and an optional format 
 publicKey.combine([privateKey.publicKey], format: .uncompressed)
 ```
+
+*→ Full API: [docs.21.dev/documentation/p256k/p256k/signing/publickey](https://docs.21.dev/documentation/p256k/p256k/signing/publickey)*
 
 ### PEM Key Format
 
@@ -253,6 +267,8 @@ oUQDQgAEt2uDn+2GqqYs/fmkBr5+rCQ3oiFSIJMAcjHIrTDS6HEELgguOatmFBOp
 // Import keys generated from OpenSSL
 let privateKey = try! P256K.Signing.PrivateKey(pemRepresentation: privateKeyString)
 ```
+
+*→ Full API: [docs.21.dev/documentation/p256k/serializingkeys](https://docs.21.dev/documentation/p256k/serializingkeys)*
 
 ### MuSig2
 
@@ -314,6 +330,8 @@ let isValid = aggregateKey.isValidSignature(
 
 print("Is valid MuSig signature: \(isValid)")
 ```
+
+*→ Full API: [docs.21.dev/documentation/p256k/musig2multisignatures](https://docs.21.dev/documentation/p256k/musig2multisignatures)*
 
 ## Security
 

--- a/Sources/P256K/P256K.docc/EllipticCurveDiffieHellman.md
+++ b/Sources/P256K/P256K.docc/EllipticCurveDiffieHellman.md
@@ -1,0 +1,130 @@
+# Elliptic Curve Diffie-Hellman
+
+@Metadata {
+    @TitleHeading("How-to Guide")
+}
+
+Derive a shared secret between two parties over secp256k1 using ECDH key agreement, the foundation of Nostr NIP-04 encryption, BIP-352 Silent Payments, and Lightning's Noise XK handshake.
+
+## Overview
+
+Elliptic Curve Diffie-Hellman (ECDH) is the elliptic-curve form of the original [Diffie-Hellman key exchange](https://datatracker.ietf.org/doc/html/rfc2631) (1976). Two parties — Alice with key pair `(a, A)` and Bob with key pair `(b, B)`, where `A = a·G` and `B = b·G` — can each independently compute the same shared point:
+
+```
+S = a·B = a·(b·G) = b·(a·G) = b·A
+```
+
+Neither party transmits a secret. An eavesdropper observing only the public keys `A` and `B` cannot derive `S` without solving the [elliptic curve discrete logarithm problem](https://en.wikipedia.org/wiki/Elliptic-curve_cryptography#Rationale), which is computationally infeasible on secp256k1 at the 128-bit security level.
+
+This package implements ECDH on the secp256k1 curve via libsecp256k1's [`secp256k1_ecdh`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_ecdh.h) function. ECDH on secp256k1 is the building block for several open-protocol stacks:
+
+- **[BIP-352 Silent Payments](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)** — sender derives a unique destination output from receiver's static address (see <doc:SilentPayments>).
+- **[Nostr NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md)** — encrypted direct messages between Nostr identities (note: NIP-04 has known confidentiality limitations; NIP-44 supersedes it).
+- **[Lightning's Noise XK handshake](https://github.com/lightning/bolts/blob/master/08-transport.md)** — establishes the encrypted transport between Lightning Network peers.
+- **Hybrid encryption schemes** — ECIES variants combining ECDH with a symmetric AEAD.
+
+### The Key Agreement Namespace
+
+All ECDH operations live under ``P256K/KeyAgreement``:
+
+```swift
+import P256K
+
+let alicePrivateKey = try P256K.KeyAgreement.PrivateKey()
+let bobPrivateKey = try P256K.KeyAgreement.PrivateKey()
+
+let alicePublicKey = alicePrivateKey.publicKey
+let bobPublicKey = bobPrivateKey.publicKey
+```
+
+``P256K/KeyAgreement/PrivateKey`` is byte-compatible with ``P256K/Signing/PrivateKey`` — you can convert between them via `dataRepresentation` when a single key serves both roles (signing and key agreement).
+
+### Computing a Shared Secret
+
+Each party calls `sharedSecretFromKeyAgreement(with:)` with the other party's public key. Both produce identical output:
+
+```swift
+let aliceShared = alicePrivateKey.sharedSecretFromKeyAgreement(with: bobPublicKey)
+let bobShared = bobPrivateKey.sharedSecretFromKeyAgreement(with: alicePublicKey)
+
+// aliceShared.bytes == bobShared.bytes
+```
+
+The returned ``SharedSecret`` wraps the **raw serialized EC point** in compressed form (33 bytes: `0x02`/`0x03` prefix + 32-byte x-coordinate). This differs from libsecp256k1's upstream default (`secp256k1_ecdh_hash_function_sha256`, which would return a SHA-256 of the compressed point) — this package surfaces the unhashed point so callers can pipe it into whatever KDF their protocol requires.
+
+### Format Selection
+
+The default is `.compressed` (33 bytes). For protocols that mandate the full point (uncompressed SEC1 encoding, 65 bytes: `0x04` prefix + 32-byte x + 32-byte y):
+
+```swift
+let sharedUncompressed = alicePrivateKey.sharedSecretFromKeyAgreement(
+    with: bobPublicKey,
+    format: .uncompressed
+)
+// sharedUncompressed.bytes.count == 65
+```
+
+Choose compressed unless interoperability with a protocol that requires uncompressed encoding (for example, some legacy ECIES variants, or specific OpenSSL-generated key material) forces the larger form. See <doc:KeyFormats> for the broader format-selection story.
+
+### Deriving a Symmetric Key
+
+The raw shared point should not be used directly as a symmetric key. Always run it through a key-derivation function (KDF). Three common patterns:
+
+**SHA-256 (simplest, suitable for ad-hoc symmetric key derivation):**
+
+```swift
+let symmetricKey = SHA256.hash(data: aliceShared.bytes)
+// 32-byte key suitable for AES-256 or ChaCha20
+```
+
+**BIP-340 tagged SHA-256 (for protocols like BIP-352 that specify a domain-separation tag):**
+
+```swift
+let tagged = SHA256.taggedHash(
+    tag: "BIP0352/SharedSecret".data(using: .utf8)!,
+    data: aliceShared.bytes
+)
+```
+
+**HKDF (when you need multiple keys from one shared secret, or a non-SHA-256 underlying hash):** use Apple's `swift-crypto` `HKDF` API or `CryptoKit.HKDF` with `aliceShared.bytes` as input keying material.
+
+### Protocols Using ECDH on secp256k1
+
+| Protocol | Spec | What ECDH derives |
+|---|---|---|
+| BIP-352 Silent Payments | [BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) | Per-output destination tweak |
+| Nostr NIP-04 | [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md) | AES-CBC encryption key for DMs |
+| Lightning Noise XK | [BOLT 8](https://github.com/lightning/bolts/blob/master/08-transport.md) | ChaCha20-Poly1305 transport keys |
+| ECIES (generic) | [SEC 1 §5.1](https://www.secg.org/sec1-v2.pdf) | Symmetric encryption + MAC keys |
+
+For the BIP-352 case specifically, see the dedicated <doc:SilentPayments> guide — the protocol layers an input hash, a counter, and BIP-340 tagged hashing on top of the basic ECDH primitive.
+
+### Production Considerations
+
+#### Side-channel guarantees
+
+ECDH multiplication uses a different curve-arithmetic path than ECDSA/Schnorr signing. As noted in <doc:SecurityConsiderations>, **context randomization does not provide side-channel protection for ECDH** on this code path. If your threat model requires constant-time guarantees against power or timing analysis, audit the underlying `secp256k1_ecdh` invocation against your target hardware.
+
+#### Authenticate the peer's public key
+
+ECDH alone provides confidentiality against passive eavesdroppers but says nothing about who you exchanged secrets with. A man-in-the-middle who substitutes their own public key for `B` derives a shared secret with Alice, and separately derives a different shared secret with Bob, then proxies traffic between them. Always pair ECDH with peer-key authentication — typically via a signature, a certificate, or out-of-band fingerprint verification (the [Noise framework](https://noiseprotocol.org/) integrates both).
+
+#### Static vs ephemeral keys
+
+ECDH keys can be **static** (long-lived, like a Nostr identity) or **ephemeral** (single-session, like Noise XK's `e` keys). Ephemeral keys provide forward secrecy: compromising a long-term key after the fact does not let an attacker decrypt past sessions. Use ephemeral keys for transport encryption; reserve static keys for identity and signature operations.
+
+### Further Reading
+
+- [BIP-352: Silent Payments specification](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)
+- [Nostr NIP-04: Encrypted Direct Message](https://github.com/nostr-protocol/nips/blob/master/04.md)
+- [BOLT 8: Encrypted and Authenticated Transport](https://github.com/lightning/bolts/blob/master/08-transport.md)
+- [SEC 1: Elliptic Curve Cryptography v2](https://www.secg.org/sec1-v2.pdf) (sections 3.3 and 5.1)
+- [Noise Protocol Framework](https://noiseprotocol.org/)
+
+## See Also
+
+- <doc:GettingStarted>
+- <doc:SilentPayments>
+- <doc:SecurityConsiderations>
+- ``P256K/KeyAgreement``
+- ``SharedSecret``

--- a/Sources/P256K/P256K.docc/GettingStarted.md
+++ b/Sources/P256K/P256K.docc/GettingStarted.md
@@ -135,8 +135,12 @@ let bobSharedSecret = bobPrivateKey.sharedSecretFromKeyAgreement(with: alicePubl
 
 > Note: Context randomization does not provide side-channel protection for ECDH. The ECDH module uses a different kind of elliptic curve point multiplication that does not currently benefit from base point blinding.
 
-### Next Steps
+## See Also
 
-- **MuSig2 multi-signatures**: Use ``P256K/MuSig`` to aggregate public keys and produce a single Schnorr signature from multiple independent signers, as defined by BIP-327.
-- **ECDSA key recovery**: Use ``P256K/Recovery`` to recover a public key from a recoverable ECDSA signature and recovery ID.
-- **Zero-knowledge proofs**: Import the `ZKP` module for range proofs, surjection proofs, and adaptor signatures built on the `libsecp256k1-zkp` library.
+- <doc:EllipticCurveDiffieHellman>
+- <doc:SilentPayments>
+- <doc:MuSig2MultiSignatures>
+- <doc:TweakingKeys>
+- <doc:RecoveringPublicKeys>
+- <doc:SerializingKeys>
+- <doc:SecurityConsiderations>

--- a/Sources/P256K/P256K.docc/KeyFormats.md
+++ b/Sources/P256K/P256K.docc/KeyFormats.md
@@ -81,3 +81,9 @@ The `rawValue` maps directly to the flag passed to the underlying C library's se
 - **Default to compressed** for all new applications. It is the standard for Bitcoin, smaller, and fully supported.
 - **Use x-only** when working with Schnorr signatures, Taproot, or MuSig2.
 - **Use uncompressed** only when required by a legacy protocol or for compatibility with systems that expect the `0x04` prefix.
+
+## See Also
+
+- <doc:SerializingKeys>
+- <doc:GettingStarted>
+- ``P256K/Format``

--- a/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
+++ b/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
@@ -97,3 +97,12 @@ let isPartialValid = aggregate.isValidSignature(
     for: messageHash
 )
 ```
+
+## See Also
+
+- <doc:TweakingKeys>
+- <doc:SilentPayments>
+- <doc:KeyFormats>
+- <doc:SerializingKeys>
+- ``P256K/Schnorr``
+- ``P256K/MuSig``

--- a/Sources/P256K/P256K.docc/P256K.md
+++ b/Sources/P256K/P256K.docc/P256K.md
@@ -12,7 +12,26 @@ The P256K module wraps the `libsecp256k1` C library with a type-safe Swift API d
 
 All operations require a secp256k1 context. The library provides a shared ``P256K/Context`` that is created and randomized once at process startup, protecting ECDSA signing, Schnorr signing, and public key generation against timing and power analysis attacks via base point blinding.
 
+### Where to start
+
+New to `P256K`? Begin with <doc:GettingStarted> for a task-oriented walkthrough of ECDSA signing, BIP-340 Schnorr signatures, and ECDH key agreement. Aggregating signatures across multiple signers? Read <doc:MuSig2MultiSignatures> for the BIP-327 protocol. The <doc:EllipticCurveDiffieHellman> guide covers ECDH end-to-end — the building block behind Nostr NIP-04, Lightning's Noise XK handshake, and BIP-352 Silent Payments. Sending Bitcoin to a reusable receiver address without on-chain linkability lives in <doc:SilentPayments>. Working with tweaks (BIP-32 derivation, Taproot key paths) is covered in <doc:TweakingKeys>. Persisting keys? See <doc:SerializingKeys> and the conceptual <doc:KeyFormats>. Recovering public keys from signatures (BIP-137 / BIP-322) lives in <doc:RecoveringPublicKeys>. Production-readiness caveats — context randomization, nonce hygiene, comparison timing, secret zeroization, signature malleability — are in <doc:SecurityConsiderations>.
+
 ## Topics
+
+### Guides
+
+- <doc:GettingStarted>
+- <doc:EllipticCurveDiffieHellman>
+- <doc:SilentPayments>
+- <doc:MuSig2MultiSignatures>
+- <doc:TweakingKeys>
+- <doc:RecoveringPublicKeys>
+- <doc:SerializingKeys>
+
+### Concepts
+
+- <doc:SecurityConsiderations>
+- <doc:KeyFormats>
 
 ### Essentials
 
@@ -66,16 +85,3 @@ All operations require a secp256k1 context. The library provides a shared ``P256
 - ``UInt256``
 - ``secp256k1Error``
 - ``CryptoKitError``
-
-### Guides
-
-- <doc:GettingStarted>
-- <doc:MuSig2MultiSignatures>
-- <doc:TweakingKeys>
-- <doc:RecoveringPublicKeys>
-- <doc:SerializingKeys>
-
-### Concepts
-
-- <doc:SecurityConsiderations>
-- <doc:KeyFormats>

--- a/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
+++ b/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
@@ -73,3 +73,9 @@ standardSignature.derRepresentation    // DER-encoded
 ```
 
 > Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's BIP-62 rule 6), pass the result through `secp256k1_ecdsa_signature_normalize` before verifying.
+
+## See Also
+
+- <doc:GettingStarted>
+- <doc:SecurityConsiderations>
+- ``P256K/Recovery``

--- a/Sources/P256K/P256K.docc/SecurityConsiderations.md
+++ b/Sources/P256K/P256K.docc/SecurityConsiderations.md
@@ -70,3 +70,10 @@ P256K uses `SecureBytes` internally for private key storage. When a `SecureBytes
 An ECDSA signature `(r, s)` has a counterpart `(r, n - s)` that is also valid for the same message and public key. This **malleability** can cause problems in systems that use the signature as a unique transaction identifier (e.g., Bitcoin before SegWit).
 
 P256K enforces **lower-S normalization** (BIP-62 rule 6): `secp256k1_ecdsa_verify` only accepts signatures where `s` is in the lower half of the curve order. The `signature(for:)` overloads on ``P256K/Signing/PrivateKey`` always produce normalized signatures, and the `normalize` property on a recoverable signature (``P256K/Recovery/ECDSASignature``) converts it to the canonical form.
+
+## See Also
+
+- <doc:GettingStarted>
+- <doc:EllipticCurveDiffieHellman>
+- <doc:MuSig2MultiSignatures>
+- ``P256K/Context``

--- a/Sources/P256K/P256K.docc/SerializingKeys.md
+++ b/Sources/P256K/P256K.docc/SerializingKeys.md
@@ -117,3 +117,9 @@ let fullKey = P256K.Signing.PublicKey(xonlyKey: xonly)
 | X-only | 32 bytes | None | BIP-340 Schnorr, Taproot |
 | DER (private) | ~118 bytes | ASN.1 | Interoperability |
 | PEM (private) | ~227 bytes | Base64 + header | Human-readable storage |
+
+## See Also
+
+- <doc:KeyFormats>
+- <doc:GettingStarted>
+- ``P256K/Format``

--- a/Sources/P256K/P256K.docc/SilentPayments.md
+++ b/Sources/P256K/P256K.docc/SilentPayments.md
@@ -1,0 +1,216 @@
+# Silent Payments
+
+@Metadata {
+    @TitleHeading("How-to Guide")
+}
+
+Send Bitcoin to a reusable static address without on-chain linkability or sender–receiver interaction, using the [BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) Silent Payments protocol.
+
+## Overview
+
+[Silent Payments](https://bitcoinops.org/en/topics/silent-payments/) ([BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki), Status: Complete, Version 1.0.2) lets a receiver publish a single static address while still receiving every payment to a fresh, unlinkable on-chain output. The sender derives the destination locally using ECDH between the receiver's published scan key and the sender's transaction inputs — no notification transactions, no out-of-band coordination, no on-chain footprint identifying the receiver.
+
+This solves the long-standing tension between **address reuse** (privacy-degrading; reveals that the same wallet received multiple payments) and **interactive address generation** (often infeasible — donations, content monetization, recurring payroll). Existing alternatives such as BIP-47 PayNyms or stealth-address protocols require on-chain notification transactions that increase fees and reveal metadata. BIP-352 produces transactions indistinguishable from any other taproot spend.
+
+The trade-off is **scanning cost**: receivers must perform an ECDH multiplication per scanned transaction. This is feasible for full nodes; light-client support is an area of [open research](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki#appendix-a-light-client-support).
+
+This guide walks through the cryptographic core of BIP-352 using `P256K`'s primitives. **It is an educational walkthrough, not a complete BIP-352 implementation** — see the [Production Considerations](#Production-Considerations) and [Reference Implementations](#Reference-Implementations) sections for everything you must add for a wallet-grade integration.
+
+### The Core Formula
+
+The simple case (one input, no labels, no scan/spend split) reduces to one line:
+
+```
+P = B + hash(a·B)·G
+```
+
+where `a` is the sender's input private key, `B` is the receiver's published public key, `G` is the secp256k1 generator. Because `a·B == b·A` (the standard ECDH identity), the receiver can compute the same `P` using their own private key `b` against the sender's public input key `A`, and scan transactions for outputs matching `P`.
+
+The full BIP-352 protocol layers four refinements on top:
+
+1. **Sum all eligible inputs** rather than one — works inside CoinJoins, makes light-client filtering tractable.
+2. **Add an input hash** committing to the smallest outpoint — prevents address reuse when the sender reuses an input set.
+3. **Add an output counter `k`** — lets a single payment produce multiple destination outputs (CoinJoin-shaped privacy, change splitting).
+4. **Split scan and spend keys** `(B_scan, B_spend)` — the receiver can keep `b_spend` in cold storage while `b_scan` runs online.
+
+The remaining refinement — labels (`B_m = B_spend + hash_BIP0352/Label(b_scan || m)·G`) — lets a single address differentiate incoming payments without re-publishing.
+
+### Tagged Hashes
+
+BIP-352 specifies three [BIP-340-style tagged hashes](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#design) to prevent cross-protocol collisions, each computed as `SHA256(SHA256(tag) || SHA256(tag) || message)`:
+
+| Tag | Used for |
+|---|---|
+| `BIP0352/Inputs` | The `input_hash` committing to the smallest outpoint |
+| `BIP0352/SharedSecret` | The shared-secret derivation `hash(input_hash·a·B || k)` |
+| `BIP0352/Label` | Optional label tweaks `hash(b_scan || m)` |
+
+`P256K` provides BIP-340 tagged hashing via ``SHA256/taggedHash(tag:data:)`` — pass the tag string above as UTF-8 bytes.
+
+### Sender: Deriving the Destination Output
+
+For a sender with a single input `(a, A)` and a receiver with published public key `B` (33-byte compressed):
+
+```swift
+import Foundation
+import P256K
+
+// Inputs: sender's private key, receiver's published public key, an outpoint
+let aliceSigningKey = try P256K.Signing.PrivateKey()  // (a, A)
+
+// Bob's `B` is published as a compressed 33-byte point; create both views.
+// `bobECDHKey` participates in ECDH; `bobSigningKey` is the base point we
+// add the shared-secret tweak to in Step 4. Both wrap the same point.
+let bobPublicKeyBytes: Data = /* 33-byte compressed B from Bob's address */
+let bobECDHKey = try P256K.KeyAgreement.PublicKey(
+    dataRepresentation: bobPublicKeyBytes,
+    format: .compressed
+)
+let bobSigningKey = try P256K.Signing.PublicKey(
+    dataRepresentation: bobPublicKeyBytes,
+    format: .compressed
+)
+
+let smallestOutpoint: Data = /* 36-byte COutPoint: little-endian txid || vout */
+
+// Step 1: input_hash = hash_BIP0352/Inputs(outpoint_L || A)
+let inputHashInput = smallestOutpoint + aliceSigningKey.publicKey.dataRepresentation
+let inputHash = SHA256.taggedHash(
+    tag: "BIP0352/Inputs".data(using: .utf8)!,
+    data: inputHashInput
+)
+
+// Step 2: ECDH between (input_hash * a) and B.
+// The spec writes the shared point as input_hash·a·B; with one input, this is
+// input_hash·a applied as a private-key tweak via `multiply`, then ECDH with B.
+let tweakedPrivateKey = try aliceSigningKey.multiply(Array(inputHash))
+let tweakedECDHKey = try P256K.KeyAgreement.PrivateKey(
+    dataRepresentation: tweakedPrivateKey.dataRepresentation
+)
+let sharedPoint = tweakedECDHKey.sharedSecretFromKeyAgreement(with: bobECDHKey)
+
+// Step 3: shared_secret_k = hash_BIP0352/SharedSecret(sharedPoint || ser_32(k))
+let k: UInt32 = 0
+let kBytes = withUnsafeBytes(of: k.bigEndian) { Data($0) }
+let sharedSecret = SHA256.taggedHash(
+    tag: "BIP0352/SharedSecret".data(using: .utf8)!,
+    data: Data(sharedPoint.bytes) + kBytes
+)
+
+// Step 4: P_k = B + sharedSecret·G — produce the BIP-341 x-only output key.
+let destination = try bobSigningKey.add(Array(sharedSecret))
+let destinationXonly = destination.xonly.bytes  // [UInt8] of length 32
+// The taproot scriptPubKey is: OP_1 OP_PUSHBYTES_32 <destinationXonly>
+```
+
+For multiple inputs, sum the input private keys (`a = a_1 + a_2 + ... + a_n`) before computing the input hash and the ECDH step. See <doc:TweakingKeys> for the additive-tweak primitives.
+
+### Receiver: Scanning for Incoming Payments
+
+The receiver reconstructs the same shared secret using their scan key `b_scan` and the **summed input public key** `A` extracted from the candidate transaction. `B_spend` is the receiver's spend key — the base point that gets tweak-added to produce each `P_k`:
+
+```swift
+let bobScanKey: P256K.KeyAgreement.PrivateKey = /* b_scan */
+let bobSpendBytes: Data = /* B_spend as 33-byte compressed point */
+let bobSpendKey = try P256K.Signing.PublicKey(
+    dataRepresentation: bobSpendBytes,
+    format: .compressed
+)
+
+let summedInputPubKey: P256K.KeyAgreement.PublicKey = /* A from tx inputs */
+let smallestOutpoint: Data = /* same 36-byte COutPoint as sender */
+
+// Step 1: reproduce input_hash with summed input pubkey (A)
+let inputHashInput = smallestOutpoint + summedInputPubKey.dataRepresentation
+let inputHash = SHA256.taggedHash(
+    tag: "BIP0352/Inputs".data(using: .utf8)!,
+    data: inputHashInput
+)
+
+// Step 2: ECDH on receiver's side: input_hash·b_scan·A
+// (KeyAgreement.PrivateKey exposes raw bytes as `rawRepresentation`,
+//  unlike the other private-key types which use `dataRepresentation`.)
+let tweakedScanKey = try P256K.Signing.PrivateKey(
+    dataRepresentation: bobScanKey.rawRepresentation
+).multiply(Array(inputHash))
+let tweakedScanECDH = try P256K.KeyAgreement.PrivateKey(
+    dataRepresentation: tweakedScanKey.dataRepresentation
+)
+let sharedPoint = tweakedScanECDH.sharedSecretFromKeyAgreement(with: summedInputPubKey)
+
+// Step 3 & 4: derive P_k for k = 0, 1, 2... and check transaction outputs
+var k: UInt32 = 0
+let txOutputs: [Data] = /* x-only output keys from the candidate tx */
+
+while true {
+    let kBytes = withUnsafeBytes(of: k.bigEndian) { Data($0) }
+    let sharedSecret = SHA256.taggedHash(
+        tag: "BIP0352/SharedSecret".data(using: .utf8)!,
+        data: Data(sharedPoint.bytes) + kBytes
+    )
+    let candidate = try bobSpendKey.add(Array(sharedSecret))
+    let candidateXonly = candidate.xonly.bytes  // [UInt8] of length 32
+
+    if !txOutputs.contains(Data(candidateXonly)) {
+        break  // No more matches — stop incrementing
+    }
+    // Found a match: candidate is one of Bob's outputs.
+    // Spending key: (b_spend + sharedSecret) mod n — derive when ready to spend.
+    k += 1
+}
+```
+
+The receiver only does the per-`k` SHA-256 work after a `k=0` match, keeping the scan cost bounded.
+
+### Scan and Spend Key Separation
+
+To minimize hot-key exposure, BIP-352 separates the receiver's address into a scan key and a spend key:
+
+```
+silent-payment-address = encode(B_scan, B_spend)
+```
+
+The scanning workflow needs `b_scan` (private) plus `B_spend` (public) — both online. The signing workflow that finally spends a discovered output needs `b_spend` (private) — which can stay in cold storage. Compromise of the scanning host leaks transaction discoverability (the attacker learns that Bob received payments and how much) but **does not let the attacker spend** any output. This mirrors view-key/spend-key separation in privacy coins like Monero.
+
+### Address Encoding
+
+A BIP-352 address is a [Bech32m](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki) encoding of `ser_P(B_scan) || ser_P(B_m)` (66 bytes total) with HRP `sp` (mainnet) or `tsp` (testnets), version `q` (= v0). The minimum address length is 117 characters; implementations should accept up to 1023 characters per the [BIP-173 checksum-design recommendation](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#checksum-design).
+
+`P256K` does not currently ship a Bech32m encoder. For end-to-end address handling, pair it with a Bech32m library or implement encoding per [BIP-350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).
+
+### Production Considerations
+
+The walkthrough above shows the cryptographic core. A wallet-grade implementation also requires:
+
+- **Eligible-input filtering**. Only `P2TR`, `P2WPKH`, `P2SH-P2WPKH`, and `P2PKH` inputs (with X-only or compressed public keys) participate in shared-secret derivation. Mixed-input transactions skip ineligible inputs.
+- **Sighash flag restrictions**. Senders must use `DEFAULT`, `ALL`, `SINGLE`, or `NONE`. `ANYONECANPAY` is **unsafe** because changing inputs after signing breaks the receiver's ability to derive the shared secret.
+- **Transaction-level scan filter**. Skip transactions with no taproot output, no eligible input, or any SegWit-version-greater-than-1 input.
+- **Label support**. The change label `m = 0` is reserved and must be scanned for during wallet recovery; never hand it out as a payment label.
+- **Bech32m encoding/decoding** with HRP and version validation (`sp1q…`, `tsp1q…`).
+- **Forward compatibility**. Reading a `v1`–`v30` address means reading the first 66 bytes of the data part and discarding the rest; `v31` (`l`) is reserved for backwards-incompatible changes.
+
+The protocol explicitly leaves CoinJoin support and light-client filter design as **open research** — do not deploy BIP-352 for collaborative-input transactions without a security review, and treat any light-client implementation as experimental.
+
+### Reference Implementations
+
+For a complete BIP-352 implementation to compare against, study these:
+
+- [Bitcoin Core PR #28122](https://github.com/bitcoin/bitcoin/pull/28122) — the canonical reference implementation, written by the BIP authors.
+- [`silentpayments-rs`](https://github.com/cygnet3/silentpayments-rs) — Rust reference library used by silent-payments-light-client work.
+- [Optech Silent Payments topic](https://bitcoinops.org/en/topics/silent-payments/) — running list of newsletter coverage, ecosystem deployments, and related research.
+
+### Further Reading
+
+- [BIP-352: Silent Payments](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) — the canonical specification (authors: josibake, Ruben Somsen, Sebastian Falbesoner)
+- [Bitcoin Optech: Silent payments topic](https://bitcoinops.org/en/topics/silent-payments/) — protocol context, deployment status, related protocols
+- [Original 2022 bitcoin-dev proposal](https://gnusha.org/pi/bitcoindev/CAPv7TjbXm953U2h+-12MfJ24YqOM5Kcq77_xFTjVK+R2nf-nYg@mail.gmail.com/) by Ruben Somsen
+- [BIP-340: Schnorr Signatures](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) — tagged-hash conventions inherited by BIP-352
+- [BIP-341: Taproot output rules](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) — output encoding for Silent Payments destinations
+
+## See Also
+
+- <doc:EllipticCurveDiffieHellman>
+- <doc:TweakingKeys>
+- <doc:SecurityConsiderations>
+- ``P256K/KeyAgreement``
+- ``P256K/Schnorr``

--- a/Sources/P256K/P256K.docc/TweakingKeys.md
+++ b/Sources/P256K/P256K.docc/TweakingKeys.md
@@ -95,3 +95,9 @@ let derivedKey = try aggregate.add(Array(tweak))
 // Taproot: tweak the x-only aggregate key
 let taprootOutput = try aggregate.xonly.add(Array(tweakHash))
 ```
+
+## See Also
+
+- <doc:MuSig2MultiSignatures>
+- ``P256K/Schnorr``
+- ``P256K/Signing``

--- a/Sources/ZKP/ZKP.docc/ZKP.md
+++ b/Sources/ZKP/ZKP.docc/ZKP.md
@@ -4,7 +4,7 @@
     @TitleHeading("Framework")
 }
 
-Zero-knowledge proof primitives for the secp256k1 curve — adaptor signatures, range proofs, surjection proofs, and MuSig2 half-aggregation — layered on Blockstream's `secp256k1-zkp` fork of `libsecp256k1`.
+Swift bindings for Blockstream's `secp256k1-zkp` fork of `libsecp256k1`, adding zero-knowledge proof primitives — range proofs, surjection proofs, ECDSA and BIP-340 adaptor signatures, MuSig2 half-aggregation, and Bulletproofs++ — that drive Blockstream's [Liquid Network](https://liquid.net/).
 
 ## Overview
 
@@ -14,11 +14,18 @@ Zero-knowledge proof primitives for the secp256k1 curve — adaptor signatures, 
 
 > Note: The ZKP-exclusive zero-knowledge surface is C-only at present — Swift wrappers for range proofs, surjection proofs, adaptor signatures, and MuSig2 half-aggregation will be added incrementally. The shared surface listed below is fully supported today.
 
+### Where to start
+
+Picking between `ZKP` and ``P256K``? Read <doc:ChoosingP256KvsZKP> for the decision boundary and the trait-by-trait breakdown. The shared cryptographic surface (ECDSA, Schnorr, MuSig2, ECDH, recoverable signatures, hashing) is documented in `P256K`'s catalog — see [Getting Started](https://docs.21.dev/documentation/p256k/gettingstarted) for a task-oriented walkthrough that applies equally to both products.
+
 ## Topics
+
+### Guides
+
+- <doc:ChoosingP256KvsZKP>
 
 ### Essentials
 
-- <doc:ChoosingP256KvsZKP>
 - ``P256K``
 - ``P256K/Context``
 - ``P256K/Format``

--- a/Tests/ZKPTests/SilentPaymentsAPIShapeTests.swift
+++ b/Tests/ZKPTests/SilentPaymentsAPIShapeTests.swift
@@ -1,0 +1,143 @@
+//
+//  SilentPaymentsAPIShapeTests.swift
+//  21-DOT-DEV/swift-secp256k1
+//
+//  Copyright (c) 2026 Timechain Software Initiative, Inc.
+//  Distributed under the MIT software license
+//
+//  See the accompanying file LICENSE for information
+//
+
+#if canImport(ZKP)
+    @testable import ZKP
+#else
+    @testable import P256K
+#endif
+
+import Foundation
+import Testing
+
+/// Regression tests for the API surface used by the
+/// [`SilentPayments` DocC article](https://docs.21.dev/documentation/p256k/silentpayments).
+///
+/// Validates that the BIP-352 sender + receiver flows shown in the article
+/// compile against the published P256K API and that the math closes
+/// (Bob's reconstruction of `P_0` matches Alice's-derived destination key).
+/// This is an API-shape test, not a BIP-352 conformance test — it does not
+/// validate against the BIP's official test vectors.
+struct SilentPaymentsAPIShapeSuite {
+    @Test("BIP-352 single-input sender/receiver round-trip closes")
+    func bip352SingleInputRoundTrip() throws {
+        // ───── Setup ─────
+        // Alice (sender) holds a single input.
+        let aliceSigningKey = try P256K.Signing.PrivateKey()
+
+        // Bob (receiver) splits scan and spend keys; the spend key is what
+        // the receiver tweaks to produce P_k. Both keys live in this test;
+        // a real wallet keeps b_spend in cold storage.
+        let bobScanKey = try P256K.KeyAgreement.PrivateKey()
+        let bobSpendPrivateKey = try P256K.Signing.PrivateKey()
+        let bobSpendBytes = bobSpendPrivateKey.publicKey.dataRepresentation
+
+        // Both views of B_spend (article shows that we materialize both views
+        // when B is also being used as an ECDH peer; here only signing-side
+        // is needed since b_scan handles ECDH on the receiver side).
+        let bobSpendKey = try P256K.Signing.PublicKey(
+            dataRepresentation: bobSpendBytes,
+            format: .compressed
+        )
+
+        // For the sender flow, Alice ECDHs against B_scan (Bob's published scan key).
+        // Materialize both views of the same compressed point.
+        let bobScanPubBytes = bobScanKey.publicKey.dataRepresentation
+        let bobScanECDHKey = try P256K.KeyAgreement.PublicKey(
+            dataRepresentation: bobScanPubBytes,
+            format: .compressed
+        )
+
+        // Synthetic 36-byte outpoint (txid is 32 bytes, vout is 4 bytes; little-endian per BIP-352).
+        let smallestOutpoint = Data(repeating: 0xAB, count: 36)
+
+        // ───── Sender (Alice) ─────
+
+        // Step 1: input_hash = hash_BIP0352/Inputs(outpoint_L || A)
+        let inputHashInput = smallestOutpoint + aliceSigningKey.publicKey.dataRepresentation
+        let inputHash = try SHA256.taggedHash(
+            tag: #require("BIP0352/Inputs".data(using: .utf8)),
+            data: inputHashInput
+        )
+
+        // Step 2: ECDH between (input_hash * a) and B_scan.
+        let aliceTweakedPrivateKey = try aliceSigningKey.multiply(Array(inputHash))
+        let aliceTweakedECDHKey = try P256K.KeyAgreement.PrivateKey(
+            dataRepresentation: aliceTweakedPrivateKey.dataRepresentation
+        )
+        let aliceSharedPoint = aliceTweakedECDHKey.sharedSecretFromKeyAgreement(with: bobScanECDHKey)
+
+        // Step 3: shared_secret_k = hash_BIP0352/SharedSecret(sharedPoint || ser_32(k))
+        let k: UInt32 = 0
+        let kBytes = withUnsafeBytes(of: k.bigEndian) { Data($0) }
+        let aliceSharedSecret = try SHA256.taggedHash(
+            tag: #require("BIP0352/SharedSecret".data(using: .utf8)),
+            data: Data(aliceSharedPoint.bytes) + kBytes
+        )
+
+        // Step 4: P_0 = B_spend + sharedSecret·G — derive the BIP-341 x-only output key.
+        let destination = try bobSpendKey.add(Array(aliceSharedSecret))
+        let destinationXonly = destination.xonly.bytes
+
+        #expect(destinationXonly.count == 32, "BIP-341 taproot x-only output key is 32 bytes")
+
+        // ───── Receiver (Bob) ─────
+
+        // Bob extracts A from the transaction. Round-trip via dataRepresentation
+        // to produce the KeyAgreement.PublicKey form used for ECDH.
+        let summedInputPubKey = try P256K.KeyAgreement.PublicKey(
+            dataRepresentation: aliceSigningKey.publicKey.dataRepresentation,
+            format: .compressed
+        )
+
+        // Step 1: reproduce input_hash with the summed input pubkey (A).
+        let bobInputHashInput = smallestOutpoint + summedInputPubKey.dataRepresentation
+        let bobInputHash = try SHA256.taggedHash(
+            tag: #require("BIP0352/Inputs".data(using: .utf8)),
+            data: bobInputHashInput
+        )
+
+        #expect(
+            Data(Array(bobInputHash)) == Data(Array(inputHash)),
+            "Sender and receiver compute identical input_hash"
+        )
+
+        // Step 2: ECDH on Bob's side: input_hash·b_scan·A
+        // Note: KeyAgreement.PrivateKey exposes raw bytes via `rawRepresentation`,
+        // not `dataRepresentation` (the only such asymmetry in the public API).
+        let tweakedScanKey = try P256K.Signing.PrivateKey(
+            dataRepresentation: bobScanKey.rawRepresentation
+        ).multiply(Array(bobInputHash))
+        let tweakedScanECDH = try P256K.KeyAgreement.PrivateKey(
+            dataRepresentation: tweakedScanKey.dataRepresentation
+        )
+        let bobSharedPoint = tweakedScanECDH.sharedSecretFromKeyAgreement(with: summedInputPubKey)
+
+        #expect(
+            Data(aliceSharedPoint.bytes) == Data(bobSharedPoint.bytes),
+            "ECDH produces identical shared point on both sides — the BIP-352 core invariant"
+        )
+
+        // Step 3: derive shared_secret_0 on Bob's side.
+        let bobSharedSecret = try SHA256.taggedHash(
+            tag: #require("BIP0352/SharedSecret".data(using: .utf8)),
+            data: Data(bobSharedPoint.bytes) + kBytes
+        )
+
+        // Step 4: candidate_0 = B_spend + bobSharedSecret·G
+        let candidate = try bobSpendKey.add(Array(bobSharedSecret))
+        let candidateXonly = candidate.xonly.bytes
+
+        #expect(
+            candidateXonly == destinationXonly,
+            "Receiver reconstructs the same destination output as the sender derived"
+        )
+    }
+}


### PR DESCRIPTION
- README.md: add docs.21.dev links after each code example (Signing, Schnorr, Tweak, ECDH, Silent Payments, Recovery, Combine Public Keys, PEM, MuSig2)
- .spi.yml: update documentation URL to p256k/ subpath
- EllipticCurveDiffieHellman.md: new guide covering ECDH key agreement, shared secret derivation, format selection, KDF patterns, BIP-352/NIP-04/BOLT-8 use cases, and side-channel/authentication caveats
- New SilentPayments.md