### PR TITLE
ci(subtree): drop scheduled trigger from check-subtree-updates

### DIFF
--- a/.github/workflows/check-subtree-updates.yml
+++ b/.github/workflows/check-subtree-updates.yml
@@ -1,8 +1,8 @@
 name: Check Subtree Updates
 
 on:
-  schedule:
-    - cron: '0 6,18 * * *'
+  # Scheduled runs disabled to cap GitHub Actions usage. Re-add a
+  # `schedule:` block here if you want cron-driven update checks again.
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Stop the cron-driven update checks that were running at 06:00 and 18:00 UTC. The `workflow_dispatch:` trigger remains, so the check can still be invoked manually from the Actions tab when an upstream sync is desired. The `update-subtree.yml` workflow is already manual-only; disabling the scheduled check means nothing auto-dispatches it.

Re-add a `schedule:` block to this file to restore cron-driven checks.