### PR TITLE
docs: clarify terminology and tighten phrasing across DocC catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,8 @@ iOSInjectionProject/
 
 # mcp
 .mcp_data/
+
+# DocC suite per-catalog state. The docc-symbols / docc-articles / docc-audit
+# skills write here at catalog root; ignore at any depth to defend against
+# stray writes from eval sessions running against fixtures.
+.docc-suite-state/

--- a/Sources/P256K/P256K.docc/CryptoKitP256AndSecp256k1.md
+++ b/Sources/P256K/P256K.docc/CryptoKitP256AndSecp256k1.md
@@ -1,0 +1,154 @@
+# Why CryptoKit's P256 Can't Sign Bitcoin or Nostr
+
+@Metadata {
+    @TitleHeading("Explanation")
+}
+
+Apple's CryptoKit and swift-crypto expose elliptic-curve primitives on NIST P-256, P-384, P-521, and Curve25519, but not secp256k1 — the curve Bitcoin, Lightning, and Nostr require. The ``P256K`` module provides the secp256k1 equivalents with a CryptoKit-shaped API.
+
+## Overview
+
+### The short answer
+
+If you reached for CryptoKit's `P256` or its swift-crypto equivalent to sign a Bitcoin transaction, a Lightning channel update, or a Nostr event, the type compiles but the cryptography does not interoperate with those protocols. CryptoKit's `P256` is NIST P-256 — an entirely different elliptic curve from secp256k1, the curve Bitcoin and every protocol derived from it require. No combination of flags, key formats, or hash functions in CryptoKit will produce a signature that a Bitcoin node, a Lightning peer, or a Nostr relay will accept.
+
+The ``P256K`` module provides the secp256k1 equivalents under a deliberately CryptoKit-shaped API. ECDSA signing for Bitcoin transactions and signed messages lives in ``P256K/Signing``; BIP-340 Schnorr (used by Nostr events and Taproot spends) lives in ``P256K/Schnorr``; ECDH key agreement for the Lightning Noise handshake and Nostr direct messages lives in ``P256K/KeyAgreement``. The rest of this article documents *why* the mismatch exists and *which P256K type* replaces each CryptoKit call.
+
+### NIST P-256 and secp256k1 are different curves
+
+NIST P-256 and secp256k1 are two distinct elliptic curves defined over different prime fields, with different generators and different curve equations. The shared "256" refers only to the bit-length of the underlying prime field, and nothing else about them is interchangeable.
+
+The SEC 2 nomenclature makes the family explicit: the trailing letter is meaningful, not arbitrary. **secp256r1** — the curve [CryptoKit calls `P256`](https://developer.apple.com/documentation/cryptokit/p256) — is a **r**andom curve, with the coefficient `b` fixed by [ANSI X9.62's verifiable-random procedure](https://www.secg.org/sec2-v2.pdf): a published seed is hashed with SHA-1 to derive an intermediate value, and `b` is then chosen so the curve satisfies a published constraint against it. **secp256k1** is a **K**oblitz curve, a class with algebraic structure named after Neal Koblitz. Both are 256-bit prime-field curves; that is the entirety of their compatibility.
+
+The curve equations diverge immediately:
+
+- NIST P-256: `y² ≡ x³ − 3x + b (mod p)`, where `b` is fixed by the verifiable procedure above and `p = 2²⁵⁶ − 2²²⁴ + 2¹⁹² + 2⁹⁶ − 1`. The full parameters are specified in [NIST SP 800-186](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-186.pdf), the parameter document for [FIPS 186-5](https://csrc.nist.gov/pubs/fips/186-5/final).
+- secp256k1: `y² ≡ x³ + 7 (mod p)`, where `p = 2²⁵⁶ − 2³² − 977`. The full parameters are specified in [SEC 2 v2 §2.4.1](https://www.secg.org/sec2-v2.pdf).
+
+The generator points are different. The group orders are different. The set of valid public keys is different. Bytes with the right shape for a compressed key — a `0x02` or `0x03` prefix followed by 32 bytes — can be interpreted as a point on either curve, but the same bytes denote different points in different groups, and a signature produced under one curve cannot be verified under the other.
+
+Every Bitcoin-derived ecosystem — Lightning, Nostr, Stacks, and so on — inherits the same curve choice, and so requires the same secp256k1 implementation. Satoshi Nakamoto's 2008 selection has aged well: secp256k1's parameters are fully explicit, with no constants pulled from an unexplained hash, and the Koblitz structure (`a = 0`) admits a GLV endomorphism that meaningfully speeds scalar multiplication.
+
+> Important: A secp256k1 key or signature cannot be used with NIST P-256, and vice versa; the byte representations may be byte-identical but they describe points on different curves.
+
+### What CryptoKit and swift-crypto actually support
+
+[CryptoKit's](https://developer.apple.com/documentation/cryptokit) elliptic-curve surface is deliberately curated: three NIST prime curves (P-256, P-384, P-521) for ECDSA and ECDH, plus Curve25519 for Ed25519 signing and X25519 key agreement. Each of these curves has matching `Signing` and `KeyAgreement` namespaces nested under the curve type — for example, `P256.Signing` and `Curve25519.KeyAgreement`. There is no entry for secp256k1.
+
+The Secure Enclave gets an additional [`SecureEnclave.P256`](https://developer.apple.com/documentation/cryptokit/secureenclave) surface that keeps the private key bound to the device and never returns it to process memory. That hardware path is also NIST P-256 only — the Secure Enclave does not implement secp256k1.
+
+[swift-crypto](https://github.com/apple/swift-crypto) is Apple's open-source implementation used for Linux and server-side Swift, tracking CryptoKit's API. The curve catalog is the same — P-256, P-384, P-521, Curve25519 — and the same omission applies: no secp256k1 in the main module, and none in the `CryptoExtras` subset either. The name appears only as an inert OID constant in the vendored BoringSSL sources (NID 714, OID `1.3.132.0.10`) — an object identifier for ASN.1 parsing, not an implementation.
+
+The omission is deliberate and longstanding. When asked to add secp256k1 in [swift-crypto issue #8](https://github.com/apple/swift-crypto/issues/8) (filed February 2020, declined that month and reaffirmed in January 2022), the maintainers' primary recommendation was "a high-quality secp256k1 Swift open source project made available, potentially with a compatible API," specifically calling out "a Swift wrapper of the bitcoin-core implementation (or any other preferred high-quality implementation), following the API design principles used in this library." ``P256K`` is exactly that.
+
+> Note: swift-crypto and CryptoKit share an API contract by design. If a curve or primitive is missing from one, treat it as missing from both — including secp256k1.
+
+This is the core elliptic-curve surface of the Apple stack. Every Bitcoin, Lightning, and Nostr operation that depends on secp256k1 has to go through a separately-vendored library — which Apple's own maintainers recommend.
+
+### The use-case redirect, code by code
+
+``P256K`` wraps [`libsecp256k1`](https://github.com/bitcoin-core/secp256k1) — the reference implementation used by Bitcoin Core itself — and surfaces it under CryptoKit-shaped namespaces. The result is the library pattern issue #8's maintainers asked for: nested `Signing`, `Schnorr`, and `KeyAgreement` namespaces; `PrivateKey` and `PublicKey` types with `dataRepresentation`; `sharedSecretFromKeyAgreement(with:)` returning a ``SharedSecret`` type that mirrors CryptoKit's `ContiguousBytes`-conforming shape. The three subsections below pair each CryptoKit call you tried (or were about to try) with the P256K equivalent that actually interoperates with the protocol.
+
+#### ECDSA: signing Bitcoin transactions and messages
+
+ECDSA on secp256k1 is the signature primitive behind every pre-Taproot Bitcoin script and the [BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki) signed-message format. The CryptoKit call compiles against NIST P-256 and produces signatures that no Bitcoin node, Lightning peer, or BIP-137 verifier will accept:
+
+```swift
+// CryptoKit / swift-crypto — NIST P-256, NOT compatible with Bitcoin
+import CryptoKit
+
+let key = P256.Signing.PrivateKey()
+let signature = try key.signature(for: messageData)
+// signature is ECDSA over NIST P-256 — Bitcoin nodes reject
+```
+
+The ``P256K/Signing/PrivateKey`` equivalent has the same nested-namespace shape and produces signatures already lower-S normalized per [BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki), which is the only form `secp256k1_ecdsa_verify` accepts:
+
+```swift
+// P256K — secp256k1, the curve Bitcoin actually uses
+import P256K
+
+let key = try P256K.Signing.PrivateKey()
+let signature = key.signature(for: messageData)
+// signature is ECDSA over secp256k1, lower-S normalized
+```
+
+SHA-256 is applied internally before signing, matching CryptoKit's `signature(for:)` convention. Serialization is symmetric: ``P256K/Signing/ECDSASignature/compactRepresentation`` returns the 64-byte form, and ``P256K/Signing/ECDSASignature/derRepresentation`` returns the variable-length DER encoding.
+
+#### BIP-340 Schnorr: Nostr events and Taproot key-path spends
+
+[NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) signs every Nostr event with a [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signature over a 32-byte x-only public key. Bitcoin's Taproot key-path spends use the same scheme. CryptoKit has no Schnorr signature support at all — its EdDSA implementation is Ed25519 on Curve25519, which is a different signature scheme on a different curve:
+
+```swift
+// CryptoKit / swift-crypto — Ed25519, NOT BIP-340 Schnorr
+import CryptoKit
+
+let key = Curve25519.Signing.PrivateKey()
+let signature = try key.signature(for: messageData)
+// signature is Ed25519 — Nostr relays and Taproot verifiers reject
+```
+
+The P256K equivalent uses ``P256K/Schnorr/PrivateKey``, signs under BIP-340, and exposes a 32-byte x-only verifying key via `xonly` — exactly the shape NIP-01 events and Taproot output keys require:
+
+```swift
+// P256K — BIP-340 Schnorr over secp256k1, the scheme Nostr and Taproot use
+import P256K
+import Foundation
+
+let key = try P256K.Schnorr.PrivateKey()
+let digest = SHA256.hash(data: messageData)
+let signature = try key.signature(for: digest)
+let xonlyPublicKey = key.xonly.bytes   // 32 bytes — the Nostr pubkey
+```
+
+Schnorr signing in P256K takes a pre-computed digest because BIP-340 uses tagged hashes in practice, and protocols (NIP-01, BIP-341) specify their own message-domain separators.
+
+#### ECDH: Lightning channel setup and Nostr direct messages
+
+ECDH on secp256k1 underlies Lightning's encrypted-transport handshake ([BOLT-08](https://github.com/lightning/bolts/blob/master/08-transport.md) Noise XK) and Nostr direct messaging ([NIP-44](https://github.com/nostr-protocol/nips/blob/master/44.md), or legacy [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md)). CryptoKit's ECDH is on NIST P-256, so the shared secret it produces is computed against the wrong curve:
+
+```swift
+// CryptoKit / swift-crypto — ECDH on NIST P-256
+import CryptoKit
+
+let aliceKey = P256.KeyAgreement.PrivateKey()
+let bobKey   = P256.KeyAgreement.PrivateKey()
+let secret   = try aliceKey.sharedSecretFromKeyAgreement(with: bobKey.publicKey)
+// SharedSecret derived on NIST P-256 — Lightning peers and Nostr relays expect secp256k1
+```
+
+The P256K equivalent has the same shape — ``P256K/KeyAgreement/PrivateKey``, `sharedSecretFromKeyAgreement(with:)`, and a CryptoKit-shaped ``SharedSecret`` return type:
+
+```swift
+// P256K — ECDH on secp256k1, the curve Lightning and Nostr use
+import P256K
+
+let aliceKey = try P256K.KeyAgreement.PrivateKey()
+let bobKey   = try P256K.KeyAgreement.PrivateKey()
+let secret   = try aliceKey.sharedSecretFromKeyAgreement(with: bobKey.publicKey)
+// SharedSecret derived on secp256k1 — interoperable with BOLT-08 and NIP-44
+```
+
+The returned ``SharedSecret`` is a separate type from CryptoKit's but mirrors its `ContiguousBytes` shape and constant-time equality semantics, so downstream key-derivation code that operates on `ContiguousBytes` (HKDF, HMAC) drops in without an adapter layer.
+
+### What P256K is and what it is not
+
+``P256K`` wraps [`libsecp256k1`](https://github.com/bitcoin-core/secp256k1) — the high-assurance reference implementation that Bitcoin Core itself runs, engineered for constant-time execution on secret-key paths. The Swift wrapper is **pre-1.0**: the public API is not yet stable, and consumers should pin `exact:` versions in `Package.swift` to avoid surprise migrations. See <doc:SecurityConsiderations> for the full operational guidance.
+
+Three CryptoKit assumptions do not carry over:
+
+- **No Secure Enclave.** All P256K keys live in process memory. There is no hardware-bound private-key path equivalent to `SecureEnclave.P256`; the secp256k1 curve is not implemented in Apple's Secure Enclave.
+- **ECDH side-channel hygiene works differently.** Context randomization blinds operations on the fixed generator point — signing and key generation. ECDH multiplies the peer's public key, a variable point, so it relies on libsecp256k1's separate constant-time variable-base routine rather than base-point blinding.
+- **No SDK availability gating.** CryptoKit is bundled with Apple platforms and follows OS version availability rules. P256K is a third-party SwiftPM dependency with its own pre-1.0 release cadence; expect breaking changes in any pre-1.0 release.
+
+Secrets are protected by `SecureBytes` zeroization on deallocation and constant-time comparison on ``SharedSecret`` and `PrivateKey` types — mirroring CryptoKit's hygiene defaults. The upstream library's threat model and stability guarantees are documented in [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1).
+
+## See Also
+
+- <doc:GettingStarted>
+- <doc:EllipticCurveDiffieHellman>
+- <doc:KeyFormats>
+- <doc:TweakingKeys>
+- <doc:RecoveringPublicKeys>
+- <doc:SecurityConsiderations>
+- ``P256K``

--- a/Sources/P256K/P256K.docc/EllipticCurveDiffieHellman.md
+++ b/Sources/P256K/P256K.docc/EllipticCurveDiffieHellman.md
@@ -14,7 +14,7 @@ Elliptic Curve Diffie-Hellman (ECDH) is the elliptic-curve form of the original 
 S = a·B = a·(b·G) = b·(a·G) = b·A
 ```
 
-Neither party transmits a secret. An eavesdropper observing only the public keys `A` and `B` cannot derive `S` without solving the [elliptic curve discrete logarithm problem](https://en.wikipedia.org/wiki/Elliptic-curve_cryptography#Rationale), which is computationally infeasible on secp256k1 at the 128-bit security level.
+Neither party transmits a secret. An eavesdropper observing only the public keys `A` and `B` cannot derive `S` without solving the elliptic curve discrete logarithm problem, which is computationally infeasible on secp256k1 at the 128-bit security level.
 
 This package implements ECDH on the secp256k1 curve via libsecp256k1's [`secp256k1_ecdh`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1_ecdh.h) function. ECDH on secp256k1 is the building block for several open-protocol stacks:
 
@@ -92,9 +92,9 @@ let tagged = SHA256.taggedHash(
 
 | Protocol | Spec | What ECDH derives |
 |---|---|---|
-| BIP-352 Silent Payments | [BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) | Per-output destination tweak |
-| Nostr NIP-04 | [NIP-04](https://github.com/nostr-protocol/nips/blob/master/04.md) | AES-CBC encryption key for DMs |
-| Lightning Noise XK | [BOLT 8](https://github.com/lightning/bolts/blob/master/08-transport.md) | ChaCha20-Poly1305 transport keys |
+| BIP-352 Silent Payments | BIP-352 | Per-output destination tweak |
+| Nostr NIP-04 | NIP-04 | AES-CBC encryption key for DMs |
+| Lightning Noise XK | BOLT 8 | ChaCha20-Poly1305 transport keys |
 | ECIES (generic) | [SEC 1 §5.1](https://www.secg.org/sec1-v2.pdf) | Symmetric encryption + MAC keys |
 
 For the BIP-352 case specifically, see the dedicated <doc:SilentPayments> guide — the protocol layers an input hash, a counter, and BIP-340 tagged hashing on top of the basic ECDH primitive.
@@ -107,19 +107,11 @@ ECDH multiplication uses a different curve-arithmetic path than ECDSA/Schnorr si
 
 #### Authenticate the peer's public key
 
-ECDH alone provides confidentiality against passive eavesdroppers but says nothing about who you exchanged secrets with. A man-in-the-middle who substitutes their own public key for `B` derives a shared secret with Alice, and separately derives a different shared secret with Bob, then proxies traffic between them. Always pair ECDH with peer-key authentication — typically via a signature, a certificate, or out-of-band fingerprint verification (the [Noise framework](https://noiseprotocol.org/) integrates both).
+ECDH alone provides confidentiality against passive eavesdroppers but says nothing about who you exchanged secrets with. A man-in-the-middle who substitutes their own public key for `B` derives a shared secret with Alice, and separately derives a different shared secret with Bob, then proxies traffic between them. Always pair ECDH with peer-key authentication — typically via a signature, a certificate, or out-of-band fingerprint verification (the Noise Protocol Framework integrates both).
 
 #### Static vs ephemeral keys
 
 ECDH keys can be **static** (long-lived, like a Nostr identity) or **ephemeral** (single-session, like Noise XK's `e` keys). Ephemeral keys provide forward secrecy: compromising a long-term key after the fact does not let an attacker decrypt past sessions. Use ephemeral keys for transport encryption; reserve static keys for identity and signature operations.
-
-### Further Reading
-
-- [BIP-352: Silent Payments specification](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)
-- [Nostr NIP-04: Encrypted Direct Message](https://github.com/nostr-protocol/nips/blob/master/04.md)
-- [BOLT 8: Encrypted and Authenticated Transport](https://github.com/lightning/bolts/blob/master/08-transport.md)
-- [SEC 1: Elliptic Curve Cryptography v2](https://www.secg.org/sec1-v2.pdf) (sections 3.3 and 5.1)
-- [Noise Protocol Framework](https://noiseprotocol.org/)
 
 ## See Also
 

--- a/Sources/P256K/P256K.docc/EllipticCurveDiffieHellman.md
+++ b/Sources/P256K/P256K.docc/EllipticCurveDiffieHellman.md
@@ -44,6 +44,8 @@ let bobPublicKey = bobPrivateKey.publicKey
 Each party calls `sharedSecretFromKeyAgreement(with:)` with the other party's public key. Both produce identical output:
 
 ```swift
+import P256K
+
 let aliceShared = alicePrivateKey.sharedSecretFromKeyAgreement(with: bobPublicKey)
 let bobShared = bobPrivateKey.sharedSecretFromKeyAgreement(with: alicePublicKey)
 
@@ -57,6 +59,8 @@ The returned ``SharedSecret`` wraps the **raw serialized EC point** in compresse
 The default is `.compressed` (33 bytes). For protocols that mandate the full point (uncompressed SEC1 encoding, 65 bytes: `0x04` prefix + 32-byte x + 32-byte y):
 
 ```swift
+import P256K
+
 let sharedUncompressed = alicePrivateKey.sharedSecretFromKeyAgreement(
     with: bobPublicKey,
     format: .uncompressed
@@ -73,6 +77,8 @@ The raw shared point should not be used directly as a symmetric key. Always run 
 **SHA-256 (simplest, suitable for ad-hoc symmetric key derivation):**
 
 ```swift
+import P256K
+
 let symmetricKey = SHA256.hash(data: aliceShared.bytes)
 // 32-byte key suitable for AES-256 or ChaCha20
 ```
@@ -80,6 +86,9 @@ let symmetricKey = SHA256.hash(data: aliceShared.bytes)
 **BIP-340 tagged SHA-256 (for protocols like BIP-352 that specify a domain-separation tag):**
 
 ```swift
+import Foundation
+import P256K
+
 let tagged = SHA256.taggedHash(
     tag: "BIP0352/SharedSecret".data(using: .utf8)!,
     data: aliceShared.bytes
@@ -115,6 +124,7 @@ ECDH keys can be **static** (long-lived, like a Nostr identity) or **ephemeral**
 
 ## See Also
 
+- <doc:CryptoKitP256AndSecp256k1>
 - <doc:GettingStarted>
 - <doc:SilentPayments>
 - <doc:SecurityConsiderations>

--- a/Sources/P256K/P256K.docc/GettingStarted.md
+++ b/Sources/P256K/P256K.docc/GettingStarted.md
@@ -47,6 +47,8 @@ Context randomization seeds a blinding factor that protects ECDSA signing, Schno
 To create an ECDSA key pair, initialize a ``P256K/Signing/PrivateKey``. The private half derives its verifying counterpart on demand:
 
 ```swift
+import P256K
+
 // Generate a random ECDSA key pair
 let privateKey = try P256K.Signing.PrivateKey()
 let publicKey = privateKey.publicKey
@@ -58,6 +60,8 @@ let privateKeyBytes = privateKey.dataRepresentation
 To create a Schnorr key pair for [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) compatible signatures, initialize a ``P256K/Schnorr/PrivateKey``. Schnorr verification uses an x-only verifying key:
 
 ```swift
+import P256K
+
 // Generate a random Schnorr key pair (BIP-340)
 let schnorrPrivateKey = try P256K.Schnorr.PrivateKey()
 let xonlyPublicKey = schnorrPrivateKey.xonly
@@ -69,6 +73,7 @@ let xonlyPublicKey = schnorrPrivateKey.xonly
 
 ```swift
 import Foundation
+import P256K
 
 let privateKey = try P256K.Signing.PrivateKey()
 let message = "Hello, secp256k1!".data(using: .utf8)!
@@ -84,6 +89,8 @@ print(isValid) // true
 To serialize or parse a signature in DER or compact (64-byte) format:
 
 ```swift
+import P256K
+
 // DER-encoded signature (variable length, ~70 bytes)
 let derSignature = signature.derRepresentation
 
@@ -99,6 +106,9 @@ let parsed = try P256K.Signing.ECDSASignature(compactRepresentation: compactSign
 ``P256K/Schnorr/PrivateKey`` signs hash digests and produces 64-byte Schnorr signatures as defined by BIP-340. Schnorr signatures are verified using an ``P256K/Schnorr/XonlyKey``, which holds only the x-coordinate of the verifying key:
 
 ```swift
+import Foundation
+import P256K
+
 let schnorrKey = try P256K.Schnorr.PrivateKey()
 let message = "Hello, secp256k1!".data(using: .utf8)!
 
@@ -118,6 +128,8 @@ print(isValid) // true
 ``P256K/KeyAgreement/PrivateKey`` performs Elliptic Curve Diffie-Hellman (ECDH) key agreement using `secp256k1_ecdh`. Both parties derive an identical ``SharedSecret`` from their own private key and the other party's verifying key, without transmitting the secret:
 
 ```swift
+import P256K
+
 // Alice and Bob each generate a key pair
 let alicePrivateKey = try P256K.KeyAgreement.PrivateKey()
 let bobPrivateKey = try P256K.KeyAgreement.PrivateKey()
@@ -137,6 +149,7 @@ let bobSharedSecret = bobPrivateKey.sharedSecretFromKeyAgreement(with: alicePubl
 
 ## See Also
 
+- <doc:CryptoKitP256AndSecp256k1>
 - <doc:EllipticCurveDiffieHellman>
 - <doc:SilentPayments>
 - <doc:MuSig2MultiSignatures>

--- a/Sources/P256K/P256K.docc/GettingStarted.md
+++ b/Sources/P256K/P256K.docc/GettingStarted.md
@@ -12,7 +12,7 @@ This guide walks through the four most common P256K workflows end-to-end: adding
 
 ### Adding P256K to Your Project
 
-Add `swift-secp256k1` as a Swift Package Manager dependency in your `Package.swift`:
+Add `swift-secp256k1` as a [Swift Package Manager](https://www.swift.org/documentation/package-manager/) dependency in your `Package.swift`:
 
 ```swift
 // Package.swift
@@ -40,11 +40,11 @@ import P256K
 
 Every cryptographic operation in P256K depends on a secp256k1 context object managed by ``P256K/Context``. The library provides a shared context via `P256K.Context.rawRepresentation` that is created and randomized automatically at process startup. You do not need to create or manage a context for standard use — the library handles this internally for every signing, verification, and key generation call.
 
-Context randomization seeds a blinding factor that protects ECDSA signing, Schnorr signing, and public key generation against timing and power analysis attacks. ECDH key agreement uses a different kind of elliptic curve point multiplication and does not currently benefit from context randomization.
+Context randomization seeds a blinding factor that protects ECDSA signing, Schnorr signing, and key generation against timing and power analysis attacks. ECDH key agreement uses a different kind of elliptic curve point multiplication and does not currently benefit from context randomization.
 
 ### Generating Key Pairs
 
-To create an ECDSA key pair, initialize a ``P256K/Signing/PrivateKey``. The private key generates the associated public key on demand:
+To create an ECDSA key pair, initialize a ``P256K/Signing/PrivateKey``. The private half derives its verifying counterpart on demand:
 
 ```swift
 // Generate a random ECDSA key pair
@@ -55,7 +55,7 @@ let publicKey = privateKey.publicKey
 let privateKeyBytes = privateKey.dataRepresentation
 ```
 
-To create a Schnorr key pair for BIP-340 compatible signatures, initialize a ``P256K/Schnorr/PrivateKey``. Schnorr verification uses an x-only public key:
+To create a Schnorr key pair for [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) compatible signatures, initialize a ``P256K/Schnorr/PrivateKey``. Schnorr verification uses an x-only verifying key:
 
 ```swift
 // Generate a random Schnorr key pair (BIP-340)
@@ -65,7 +65,7 @@ let xonlyPublicKey = schnorrPrivateKey.xonly
 
 ### Signing and Verifying with ECDSA
 
-``P256K/Signing/PrivateKey`` signs arbitrary data directly. SHA-256 is applied internally before calling `secp256k1_ecdsa_sign`. The resulting 64-byte signature is in normalized lower-S form, which is the only form accepted by `secp256k1_ecdsa_verify`:
+``P256K/Signing/PrivateKey`` signs arbitrary data directly. SHA-256 is applied internally before calling [`secp256k1_ecdsa_sign`](https://github.com/bitcoin-core/secp256k1/blob/master/include/secp256k1.h). The resulting 64-byte signature is in normalized lower-S form ([BIP-62 rule 6](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#new-rules)), which is the only form accepted by `secp256k1_ecdsa_verify`:
 
 ```swift
 import Foundation
@@ -96,7 +96,7 @@ let parsed = try P256K.Signing.ECDSASignature(compactRepresentation: compactSign
 
 ### Signing and Verifying with Schnorr
 
-``P256K/Schnorr/PrivateKey`` signs hash digests and produces 64-byte Schnorr signatures as defined by BIP-340. Schnorr signatures are verified using an ``P256K/Schnorr/XonlyKey``, which contains only the x-coordinate of the public key:
+``P256K/Schnorr/PrivateKey`` signs hash digests and produces 64-byte Schnorr signatures as defined by BIP-340. Schnorr signatures are verified using an ``P256K/Schnorr/XonlyKey``, which holds only the x-coordinate of the verifying key:
 
 ```swift
 let schnorrKey = try P256K.Schnorr.PrivateKey()
@@ -115,7 +115,7 @@ print(isValid) // true
 
 ### Performing ECDH Key Agreement
 
-``P256K/KeyAgreement/PrivateKey`` performs Elliptic Curve Diffie-Hellman (ECDH) key agreement using `secp256k1_ecdh`. Both parties derive an identical ``SharedSecret`` from their own private key and the other party's public key, without transmitting the secret:
+``P256K/KeyAgreement/PrivateKey`` performs Elliptic Curve Diffie-Hellman (ECDH) key agreement using `secp256k1_ecdh`. Both parties derive an identical ``SharedSecret`` from their own private key and the other party's verifying key, without transmitting the secret:
 
 ```swift
 // Alice and Bob each generate a key pair

--- a/Sources/P256K/P256K.docc/KeyFormats.md
+++ b/Sources/P256K/P256K.docc/KeyFormats.md
@@ -8,15 +8,15 @@ Understand why secp256k1 has multiple key representations and when to use each o
 
 ## Overview
 
-secp256k1 public keys can be serialized in four distinct formats — compressed (33 bytes), uncompressed (65 bytes), x-only (32 bytes), and the internal libsecp256k1 `secp256k1_pubkey` structure. Each has a specific use case and interoperability story. This article explains the mathematical relationship between them, which format each Bitcoin / Lightning / Nostr protocol expects, and how to pick one for your application.
+secp256k1 public keys can be serialized in four distinct formats: compressed, uncompressed, x-only, and the internal libsecp256k1 `secp256k1_pubkey` structure. Each has a specific use case and interoperability story. The compressed and uncompressed encodings are specified in [SEC 1: Elliptic Curve Cryptography v2 §2.3.3](https://www.secg.org/sec1-v2.pdf); x-only encoding was introduced by [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) for Schnorr signatures. This article explains the mathematical relationship between them, which format each Bitcoin / Lightning / Nostr protocol expects, and how to pick one for your application.
 
 ### Elliptic Curve Points
 
-A secp256k1 public key is a point `(x, y)` on the elliptic curve. Both coordinates are 256-bit (32-byte) integers. Since the curve equation `y^2 = x^3 + 7` has exactly two solutions for each `x` value (one even, one odd), you only need the `x` coordinate plus a single bit to identify the point uniquely.
+A secp256k1 public key is a point `(x, y)` on the elliptic curve. Both coordinates are 256-bit integers. Since the curve equation `y^2 = x^3 + 7` has exactly two solutions for each `x` value (one even, one odd), you only need the `x` coordinate plus a single bit to identify the point uniquely.
 
-### Compressed Keys (33 bytes)
+### Compressed Keys
 
-The **compressed** format stores the x-coordinate with a one-byte prefix indicating the parity of y:
+The **compressed** form (33 octets) stores the x-coordinate with a one-octet prefix indicating the parity of y:
 
 - `0x02` -- y is even
 - `0x03` -- y is odd
@@ -29,9 +29,9 @@ key.publicKey.dataRepresentation.count    // 33
 key.publicKey.format                      // .compressed
 ```
 
-### Uncompressed Keys (65 bytes)
+### Uncompressed Keys
 
-The **uncompressed** format stores both coordinates with a `0x04` prefix:
+The **uncompressed** form (65 octets) stores both coordinates with a `0x04` prefix:
 
 ```swift
 let key = try P256K.Signing.PrivateKey(format: .uncompressed)
@@ -41,19 +41,19 @@ key.publicKey.format                      // .uncompressed
 
 Uncompressed keys are rarely used in modern Bitcoin but appear in legacy transactions and some non-Bitcoin protocols. P256K supports them for interoperability.
 
-### X-Only Keys (32 bytes)
+### X-Only Keys
 
-BIP-340 introduced **x-only** public keys for Schnorr signatures. These are simply the 32-byte x-coordinate with no prefix byte. The y-coordinate is implicitly defined as the **even** value.
+[BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) introduced **x-only** public keys for Schnorr signatures. These are the bare 32-octet x-coordinate with no prefix. The y-coordinate is implicitly defined as the **even** value.
 
 ```swift
 let schnorrKey = try P256K.Schnorr.PrivateKey()
 schnorrKey.xonly.bytes.count  // 32
 ```
 
-X-only keys save 1 byte per public key and simplify the Schnorr verification equation. They are used in:
-- BIP-340 Schnorr signatures
-- BIP-341 Taproot output keys
-- BIP-327 MuSig2 aggregate keys
+X-only keys save one octet per public key and simplify the Schnorr verification equation. They are used in:
+- [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signatures
+- [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) Taproot output keys
+- [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki) MuSig2 aggregate keys
 
 ### Key Parity
 
@@ -69,10 +69,10 @@ Parity matters when:
 
 ``P256K/Format`` controls key serialization:
 
-| Case | Value | Length | C Flag |
-|------|-------|--------|--------|
-| `.compressed` | `0x0202` | 33 bytes | `SECP256K1_EC_COMPRESSED` |
-| `.uncompressed` | `0x0604` | 65 bytes | `SECP256K1_EC_UNCOMPRESSED` |
+| Case | Value | Length (bytes) | C Flag |
+|------|-------|----------------|--------|
+| `.compressed` | `0x0202` | 33 | `SECP256K1_EC_COMPRESSED` |
+| `.uncompressed` | `0x0604` | 65 | `SECP256K1_EC_UNCOMPRESSED` |
 
 The `rawValue` maps directly to the flag passed to the underlying C library's serialization functions.
 

--- a/Sources/P256K/P256K.docc/KeyFormats.md
+++ b/Sources/P256K/P256K.docc/KeyFormats.md
@@ -4,7 +4,7 @@
     @TitleHeading("Explanation")
 }
 
-Understand why secp256k1 has multiple key representations and when to use each one.
+Understand why secp256k1 has multiple key representations — compressed, uncompressed, and x-only — and how ``P256K`` exposes each one for Bitcoin, Lightning, Nostr, and Taproot.
 
 ## Overview
 
@@ -24,6 +24,8 @@ The **compressed** form (33 octets) stores the x-coordinate with a one-octet pre
 This is the default format in P256K and the standard for Bitcoin since 2012:
 
 ```swift
+import P256K
+
 let key = try P256K.Signing.PrivateKey()  // compressed by default
 key.publicKey.dataRepresentation.count    // 33
 key.publicKey.format                      // .compressed
@@ -34,6 +36,8 @@ key.publicKey.format                      // .compressed
 The **uncompressed** form (65 octets) stores both coordinates with a `0x04` prefix:
 
 ```swift
+import P256K
+
 let key = try P256K.Signing.PrivateKey(format: .uncompressed)
 key.publicKey.dataRepresentation.count    // 65
 key.publicKey.format                      // .uncompressed
@@ -46,6 +50,8 @@ Uncompressed keys are rarely used in modern Bitcoin but appear in legacy transac
 [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) introduced **x-only** public keys for Schnorr signatures. These are the bare 32-octet x-coordinate with no prefix. The y-coordinate is implicitly defined as the **even** value.
 
 ```swift
+import P256K
+
 let schnorrKey = try P256K.Schnorr.PrivateKey()
 schnorrKey.xonly.bytes.count  // 32
 ```

--- a/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
+++ b/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
@@ -35,6 +35,9 @@ Key aggregation is order-independent — the same aggregate is produced regardle
 Each party independently draws a fresh nonce pair for the upcoming session. The `generate` function returns a ``P256K/Schnorr/SecureNonce`` (kept private to the caller) and a sharable pubnonce value:
 
 ```swift
+import Foundation
+import P256K
+
 let message = "Hello, MuSig!".data(using: .utf8)!
 let messageHash = SHA256.hash(data: message)
 
@@ -52,6 +55,8 @@ let aliceNonce = try P256K.MuSig.Nonce.generate(
 Each party broadcasts their sharable pubnonce. Once every contribution has been collected, aggregate them:
 
 ```swift
+import P256K
+
 let aggregateNonce = try P256K.MuSig.Nonce(aggregating: [
     aliceNonce.pubnonce, bobNonce.pubnonce, carolNonce.pubnonce
 ])
@@ -62,6 +67,8 @@ let aggregateNonce = try P256K.MuSig.Nonce(aggregating: [
 Each party produces a partial signature using their long-term private key, their own secret half from the prior round, and the aggregated commitment:
 
 ```swift
+import P256K
+
 let alicePartial = try alice.partialSignature(
     for: messageHash,
     pubnonce: aliceNonce.pubnonce,
@@ -76,6 +83,8 @@ let alicePartial = try alice.partialSignature(
 Once all partial signatures are collected, aggregate them into the final Schnorr signature:
 
 ```swift
+import P256K
+
 let finalSignature = try P256K.MuSig.aggregateSignatures([
     alicePartial, bobPartial, carolPartial
 ])
@@ -86,12 +95,16 @@ let finalSignature = try P256K.MuSig.aggregateSignatures([
 The final signature verifies against the aggregated x-only verifying key, just like any [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signature:
 
 ```swift
+import P256K
+
 let isValid = aggregate.xonly.isValidSignature(finalSignature, for: messageHash)
 ```
 
 You can also verify individual partial signatures before aggregation:
 
 ```swift
+import P256K
+
 let isPartialValid = aggregate.isValidSignature(
     alicePartial,
     publicKey: alice.publicKey,

--- a/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
+++ b/Sources/P256K/P256K.docc/MuSig2MultiSignatures.md
@@ -4,15 +4,17 @@
     @TitleHeading("How-to Guide")
 }
 
-Create a single Schnorr signature from multiple independent signers using the BIP-327 MuSig2 protocol.
+Combine partial contributions from a fixed group of co-signers into a single Schnorr signature using the [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki) MuSig2 protocol.
 
 ## Overview
 
-MuSig2 allows multiple parties to produce a single compact Schnorr signature that verifies against an aggregated public key. No observer can distinguish a MuSig2 signature from a regular Schnorr signature. This guide walks through the complete signing protocol.
+MuSig2 ([BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki); originally introduced by [Nick, Ruffing, and Seurin (CRYPTO 2021)](https://eprint.iacr.org/2020/1261)) lets a fixed group of parties produce a single compact [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signature that verifies against one aggregate group key. The result is indistinguishable on chain from a regular Schnorr signature — a Taproot spend using MuSig2 leaves the same fee footprint, the same witness size, and the same privacy properties as a single-key spend.
 
-### Aggregating Public Keys
+The protocol runs in two communication rounds. The first round exchanges fresh per-session commitments so that every participant binds themselves to a unique randomness draw before learning anyone else's contribution; the second round exchanges partial responses keyed to the agreed-upon message. The two-round split is what makes the scheme provably secure under the OMDL assumption ([Nick, Ruffing, and Seurin, §5](https://eprint.iacr.org/2020/1261)) — even if some co-signers are dishonest, they cannot extract the others' long-term keys. The sections below walk through every step end-to-end.
 
-Each signer generates a Schnorr key pair. The public keys are then aggregated into a single ``P256K/MuSig/PublicKey``:
+### Aggregating Keys
+
+Each party derives a Schnorr key pair. Their verifying halves combine into a single ``P256K/MuSig/PublicKey``:
 
 ```swift
 import P256K
@@ -26,11 +28,11 @@ let aggregate = try P256K.MuSig.aggregate([
 ])
 ```
 
-Key aggregation is order-independent -- the same aggregate is produced regardless of the order the public keys are provided.
+Key aggregation is order-independent — the same aggregate is produced regardless of the order in which the inputs are provided.
 
-### Generating Nonces
+### Round 1: Generating Nonces
 
-Each signer independently generates a nonce pair. The `generate` function returns a ``P256K/Schnorr/SecureNonce`` (the secret nonce) and a public nonce:
+Each party independently draws a fresh nonce pair for the upcoming session. The `generate` function returns a ``P256K/Schnorr/SecureNonce`` (kept private to the caller) and a sharable pubnonce value:
 
 ```swift
 let message = "Hello, MuSig!".data(using: .utf8)!
@@ -43,11 +45,11 @@ let aliceNonce = try P256K.MuSig.Nonce.generate(
 )
 ```
 
-> Warning: A `SecureNonce` is `~Copyable` by design. Using the same secret nonce in two different signing sessions **leaks the signing key**. The type system prevents accidental reuse.
+> Warning: A `SecureNonce` is `~Copyable` by design. Reusing one across two signing sessions **leaks the long-term private key**. The type system surfaces accidental reuse as a compile-time error.
 
-### Aggregating Nonces
+### Round 1 (continued): Aggregating Pubnonces
 
-Each signer shares their public nonce. Once all public nonces are collected, aggregate them:
+Each party broadcasts their sharable pubnonce. Once every contribution has been collected, aggregate them:
 
 ```swift
 let aggregateNonce = try P256K.MuSig.Nonce(aggregating: [
@@ -55,9 +57,9 @@ let aggregateNonce = try P256K.MuSig.Nonce(aggregating: [
 ])
 ```
 
-### Creating Partial Signatures
+### Round 2: Partial Signatures
 
-Each signer creates a partial signature using their private key, their secret nonce, and the aggregated nonce:
+Each party produces a partial signature using their long-term private key, their own secret half from the prior round, and the aggregated commitment:
 
 ```swift
 let alicePartial = try alice.partialSignature(
@@ -81,7 +83,7 @@ let finalSignature = try P256K.MuSig.aggregateSignatures([
 
 ### Verification
 
-The final signature verifies against the aggregated x-only public key, just like any BIP-340 Schnorr signature:
+The final signature verifies against the aggregated x-only verifying key, just like any [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) Schnorr signature:
 
 ```swift
 let isValid = aggregate.xonly.isValidSignature(finalSignature, for: messageHash)

--- a/Sources/P256K/P256K.docc/P256K.md
+++ b/Sources/P256K/P256K.docc/P256K.md
@@ -4,17 +4,17 @@
     @TitleHeading("Framework")
 }
 
-P256K is a Swift library for elliptic curve cryptography on the secp256k1 curve, providing ECDSA signing, Schnorr signatures, MuSig2 multi-signatures, ECDH key agreement, and key recovery.
+P256K is a Swift package wrapping bitcoin-core's libsecp256k1 in a type-safe API — ECDSA, Schnorr (BIP-340), MuSig2 (BIP-327), ECDH key agreement, and key recovery — for Bitcoin, Lightning, Nostr, and other open protocols built on the secp256k1 elliptic curve.
 
 ## Overview
 
-The P256K module wraps the `libsecp256k1` C library with a type-safe Swift API designed to match the style of Apple's `swift-crypto` framework. It provides cryptographic primitives for the secp256k1 elliptic curve, which is widely used in Bitcoin, Lightning Network, Nostr, and other open protocols.
+The P256K module wraps the [`libsecp256k1`](https://github.com/bitcoin-core/secp256k1) C codebase with a type-safe Swift API designed to match the style of Apple's [`swift-crypto`](https://github.com/apple/swift-crypto) framework. It surfaces cryptographic primitives for the underlying [Bitcoin](https://github.com/bitcoin/bips), [Lightning Network](https://github.com/lightning/bolts), [Nostr](https://github.com/nostr-protocol/nips), and other open-protocol stacks.
 
-All operations require a secp256k1 context. The library provides a shared ``P256K/Context`` that is created and randomized once at process startup, protecting ECDSA signing, Schnorr signing, and public key generation against timing and power analysis attacks via base point blinding.
+All operations require a secp256k1 context. The package supplies a shared ``P256K/Context`` that is created and randomized once at process startup, protecting ECDSA signatures, Schnorr signatures, and public-key generation against timing and power-analysis attacks via base-point blinding.
 
 ### Where to start
 
-New to `P256K`? Begin with <doc:GettingStarted> for a task-oriented walkthrough of ECDSA signing, BIP-340 Schnorr signatures, and ECDH key agreement. Aggregating signatures across multiple signers? Read <doc:MuSig2MultiSignatures> for the BIP-327 protocol. The <doc:EllipticCurveDiffieHellman> guide covers ECDH end-to-end — the building block behind Nostr NIP-04, Lightning's Noise XK handshake, and BIP-352 Silent Payments. Sending Bitcoin to a reusable receiver address without on-chain linkability lives in <doc:SilentPayments>. Working with tweaks (BIP-32 derivation, Taproot key paths) is covered in <doc:TweakingKeys>. Persisting keys? See <doc:SerializingKeys> and the conceptual <doc:KeyFormats>. Recovering public keys from signatures (BIP-137 / BIP-322) lives in <doc:RecoveringPublicKeys>. Production-readiness caveats — context randomization, nonce hygiene, comparison timing, secret zeroization, signature malleability — are in <doc:SecurityConsiderations>.
+Arrived from CryptoKit and wondering why `P256` doesn't work for Bitcoin or Nostr? <doc:CryptoKitP256AndSecp256k1> answers that question and maps each CryptoKit call to its `P256K` equivalent. New to `P256K`? Begin with <doc:GettingStarted> for a task-oriented walkthrough of ECDSA, BIP-340 Schnorr, and ECDH key agreement. Aggregating contributions from multiple parties into a single Schnorr signature? Read <doc:MuSig2MultiSignatures> for the BIP-327 protocol. The <doc:EllipticCurveDiffieHellman> guide covers ECDH end-to-end — the building block behind Nostr NIP-04, Lightning's Noise XK handshake, and BIP-352 Silent Payments. Sending Bitcoin to a reusable receiver address without on-chain linkability lives in <doc:SilentPayments>. Working with tweaks (BIP-32 derivation, Taproot key paths) is covered in <doc:TweakingKeys>. Persisting keys? See <doc:SerializingKeys> and the conceptual <doc:KeyFormats>. Recovering public keys from signatures (BIP-137 / BIP-322) lives in <doc:RecoveringPublicKeys>. Production-readiness caveats — context randomization, nonce hygiene, comparison timing, secret zeroization, signature malleability — are in <doc:SecurityConsiderations>.
 
 ## Topics
 
@@ -30,6 +30,7 @@ New to `P256K`? Begin with <doc:GettingStarted> for a task-oriented walkthrough 
 
 ### Concepts
 
+- <doc:CryptoKitP256AndSecp256k1>
 - <doc:SecurityConsiderations>
 - <doc:KeyFormats>
 

--- a/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
+++ b/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
@@ -8,11 +8,15 @@ Recover an ECDSA public key from a recoverable signature and its recovery ID.
 
 ## Overview
 
-ECDSA recoverable signatures attach a small (1–3 bit) **recovery ID** to a signature, letting verifiers reconstruct the signing public key from the signature and message alone. This saves one round trip in account-discovery flows and underpins Bitcoin signed-message workflows — [BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki) (legacy `signmessage`/`verifymessage` in Bitcoin Core) and [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki) (generic signed-message format). The sections below walk through creating, serializing, and recovering keys from recoverable signatures, and converting them to standard ECDSA signatures for use with APIs that expect the vanilla form.
+ECDSA recoverable signatures attach a small (1–3 bit) **recovery ID** to a signature, letting verifiers reconstruct the signing key from the signature and message alone. This saves one round trip in account-discovery flows and underpins Bitcoin signed-message workflows — [BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki) (legacy `signmessage`/`verifymessage` in Bitcoin Core) and [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki) (generic signed-message format).
+
+The mechanism leverages a structural fact about ECDSA. Every signature `(r, s)` is consistent with up to four candidate elliptic-curve points on the secp256k1 curve, and the ID encodes which of those four candidates matches the original signer's verifying key — two bits suffice (high vs. low half of the field, and even vs. odd parity). Without that hint, a verifier would have to try all four candidates and disambiguate by message content; with it, the lift is deterministic and inexpensive. The trade-off is a single extra byte on the wire — small enough that recoverable signatures dominate Bitcoin signed-message workflows even though Bitcoin's on-chain script signatures use the vanilla form.
+
+The sections below walk through creating, serializing, and reconstructing keys from a 65-byte signature payload, and converting the result to a standard ECDSA signature for APIs that expect the vanilla form.
 
 ### Creating a Recoverable Signature
 
-Use ``P256K/Recovery/PrivateKey`` to produce a recoverable ECDSA signature. Unlike standard ECDSA signatures, recoverable signatures include a recovery ID that identifies which of up to four candidate public keys produced the signature:
+Use ``P256K/Recovery/PrivateKey`` to produce a recoverable ECDSA signature. Unlike a standard ECDSA signature, this variant embeds the additional ID that identifies which of up to four candidate verifying keys produced it:
 
 ```swift
 let privateKey = try P256K.Recovery.PrivateKey(
@@ -23,9 +27,9 @@ let message = "We're all Satoshi.".data(using: .utf8)!
 let recoverySignature = privateKey.signature(for: message)
 ```
 
-### Recovering the Public Key
+### Reconstructing the Signing Key
 
-Recover the signer's public key from the message and recoverable signature:
+Lift the signer's verifying key out of the message and signature in one step:
 
 ```swift
 let recoveredKey = P256K.Recovery.PublicKey(message, signature: recoverySignature)
@@ -34,7 +38,7 @@ let recoveredKey = P256K.Recovery.PublicKey(message, signature: recoverySignatur
 recoveredKey.dataRepresentation == privateKey.publicKey.dataRepresentation
 ```
 
-You can also recover from a hash digest:
+You can also lift from a hash digest directly:
 
 ```swift
 let digest = SHA256.hash(data: message)
@@ -43,7 +47,7 @@ let recoveredKey = P256K.Recovery.PublicKey(digest, signature: recoverySignature
 
 ### Compact Representation and Recovery ID
 
-A recoverable signature can be serialized as a compact representation (64 bytes) plus a separate recovery ID (0-3):
+The signature serializes as a compact 64-byte body plus a separate ID (0-3):
 
 ```swift
 let compact = recoverySignature.compactRepresentation
@@ -62,7 +66,7 @@ let restored = try P256K.Recovery.ECDSASignature(
 
 ### Converting to Standard ECDSA
 
-Use the ``P256K/Recovery/ECDSASignature/normalize`` property to convert a recoverable signature to a standard ECDSA signature:
+Use the ``P256K/Recovery/ECDSASignature/normalize`` property to drop the ID and obtain a standard ECDSA signature:
 
 ```swift
 let standardSignature = recoverySignature.normalize
@@ -72,7 +76,7 @@ standardSignature.dataRepresentation   // 64-byte compact
 standardSignature.derRepresentation    // DER-encoded
 ```
 
-> Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's BIP-62 rule 6), pass the result through `secp256k1_ecdsa_signature_normalize` before verifying.
+> Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's [BIP-62 rule 6](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#new-rules)), pass the result through `secp256k1_ecdsa_signature_normalize` before verifying.
 
 ## See Also
 

--- a/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
+++ b/Sources/P256K/P256K.docc/RecoveringPublicKeys.md
@@ -19,6 +19,9 @@ The sections below walk through creating, serializing, and reconstructing keys f
 Use ``P256K/Recovery/PrivateKey`` to produce a recoverable ECDSA signature. Unlike a standard ECDSA signature, this variant embeds the additional ID that identifies which of up to four candidate verifying keys produced it:
 
 ```swift
+import Foundation
+import P256K
+
 let privateKey = try P256K.Recovery.PrivateKey(
     dataRepresentation: keyBytes
 )
@@ -32,6 +35,8 @@ let recoverySignature = privateKey.signature(for: message)
 Lift the signer's verifying key out of the message and signature in one step:
 
 ```swift
+import P256K
+
 let recoveredKey = P256K.Recovery.PublicKey(message, signature: recoverySignature)
 
 // The recovered key matches the original
@@ -41,6 +46,8 @@ recoveredKey.dataRepresentation == privateKey.publicKey.dataRepresentation
 You can also lift from a hash digest directly:
 
 ```swift
+import P256K
+
 let digest = SHA256.hash(data: message)
 let recoveredKey = P256K.Recovery.PublicKey(digest, signature: recoverySignature)
 ```
@@ -50,6 +57,8 @@ let recoveredKey = P256K.Recovery.PublicKey(digest, signature: recoverySignature
 The signature serializes as a compact 64-byte body plus a separate ID (0-3):
 
 ```swift
+import P256K
+
 let compact = recoverySignature.compactRepresentation
 // compact.signature -- 64-byte compact ECDSA signature
 // compact.recoveryId -- Int32 (0, 1, 2, or 3)
@@ -58,6 +67,8 @@ let compact = recoverySignature.compactRepresentation
 Reconstruct from the compact form:
 
 ```swift
+import P256K
+
 let restored = try P256K.Recovery.ECDSASignature(
     compactRepresentation: compactBytes,
     recoveryId: recoveryId
@@ -69,6 +80,8 @@ let restored = try P256K.Recovery.ECDSASignature(
 Use the ``P256K/Recovery/ECDSASignature/normalize`` property to drop the ID and obtain a standard ECDSA signature:
 
 ```swift
+import P256K
+
 let standardSignature = recoverySignature.normalize
 
 // Access standard formats
@@ -76,7 +89,7 @@ standardSignature.dataRepresentation   // 64-byte compact
 standardSignature.derRepresentation    // DER-encoded
 ```
 
-> Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's [BIP-62 rule 6](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#new-rules)), pass the result through `secp256k1_ecdsa_signature_normalize` before verifying.
+> Important: The converted signature is **not guaranteed to be lower-S normalized** and may fail `secp256k1_ecdsa_verify`. If your application requires lower-S form (e.g., Bitcoin Core's [BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki) LOW_S rule), pass the result through `secp256k1_ecdsa_signature_normalize` before verifying.
 
 ## See Also
 

--- a/Sources/P256K/P256K.docc/SecurityConsiderations.md
+++ b/Sources/P256K/P256K.docc/SecurityConsiderations.md
@@ -14,9 +14,9 @@ P256K layers a Swift API over [bitcoin-core/secp256k1](https://github.com/bitcoi
 
 Every cryptographic operation in P256K depends on a secp256k1 context managed by ``P256K/Context``. The shared context is created and **randomized** once at process startup using OS-provided entropy.
 
-Randomization seeds a blinding factor that protects **ECDSA signing**, **Schnorr signing**, and **public key generation** against timing and power analysis attacks. The blinding factor is applied to the base point multiplication, making the internal computation pattern independent of the secret key.
+Randomization seeds a blinding factor that protects **ECDSA signing**, **Schnorr signing**, and **public key generation** against timing and power analysis attacks. The blinding factor is applied to the base point multiplication, making the internal computation pattern independent of the secret key. The technique is the standard countermeasure for side-channel attacks on scalar multiplication ([Coron 1999](https://link.springer.com/chapter/10.1007/3-540-48059-5_25), the foundational reference adopted by libsecp256k1).
 
-> Note: ECDH key agreement uses a different kind of elliptic curve point multiplication and does **not** currently benefit from context randomization.
+> Note: ECDH multiplies the peer's public key, which is a variable point rather than the fixed generator, so it relies on libsecp256k1's separate constant-time variable-base routine rather than base-point blinding from context randomization.
 
 ### Nonce Reuse
 
@@ -45,7 +45,7 @@ let partial = try privateKey.partialSignature(
 
 ### ECDSA and Schnorr Nonces
 
-For standard (non-MuSig) ECDSA and Schnorr signing, P256K uses deterministic nonce generation (RFC 6979 for ECDSA, BIP-340 for Schnorr) by default, which eliminates the risk of random nonce reuse entirely.
+For standard (non-MuSig) ECDSA and Schnorr signing, P256K uses deterministic nonce generation ([RFC 6979](https://datatracker.ietf.org/doc/html/rfc6979) for ECDSA, [BIP-340 §3.2](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki#default-signing) for Schnorr) by default, which eliminates the risk of random nonce reuse entirely.
 
 ### Constant-Time Comparison
 
@@ -69,7 +69,7 @@ P256K uses `SecureBytes` internally for private key storage. When a `SecureBytes
 
 An ECDSA signature `(r, s)` has a counterpart `(r, n - s)` that is also valid for the same message and public key. This **malleability** can cause problems in systems that use the signature as a unique transaction identifier (e.g., Bitcoin before SegWit).
 
-P256K enforces **lower-S normalization** (BIP-62 rule 6): `secp256k1_ecdsa_verify` only accepts signatures where `s` is in the lower half of the curve order. The `signature(for:)` overloads on ``P256K/Signing/PrivateKey`` always produce normalized signatures, and the `normalize` property on a recoverable signature (``P256K/Recovery/ECDSASignature``) converts it to the canonical form.
+P256K enforces **lower-S normalization** ([BIP-146](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki)): `secp256k1_ecdsa_verify` only accepts signatures where `s` is in the lower half of the curve order. The `signature(for:)` overloads on ``P256K/Signing/PrivateKey`` always produce normalized signatures, and the `normalize` property on a recoverable signature (``P256K/Recovery/ECDSASignature``) converts it to the canonical form.
 
 ## See Also
 

--- a/Sources/P256K/P256K.docc/SerializingKeys.md
+++ b/Sources/P256K/P256K.docc/SerializingKeys.md
@@ -4,7 +4,7 @@
     @TitleHeading("How-to Guide")
 }
 
-Import and export keys in raw bytes, PEM, DER, and other standard formats.
+Import and export ``P256K`` secp256k1 keys in raw bytes, PEM, DER, and X.509 SubjectPublicKeyInfo — the encodings Bitcoin, Lightning, OpenSSL toolchains, and PKCS#8-based wallet storage use.
 
 ## Overview
 
@@ -21,6 +21,8 @@ The sections below cover each supported format in the order you will typically e
 The most common serialization. Use `dataRepresentation` to export and `init(dataRepresentation:format:)` to import:
 
 ```swift
+import P256K
+
 // Export (33 bytes compressed, 65 bytes uncompressed)
 let keyData = publicKey.dataRepresentation
 
@@ -34,6 +36,8 @@ let restored = try P256K.Signing.PublicKey(
 Private keys are a fixed 32-octet scalar:
 
 ```swift
+import P256K
+
 let privKeyData = privateKey.dataRepresentation  // 32 bytes
 let restored = try P256K.Signing.PrivateKey(dataRepresentation: privKeyData)
 ```
@@ -43,6 +47,8 @@ let restored = try P256K.Signing.PrivateKey(dataRepresentation: privKeyData)
 Import keys from PEM-encoded strings. Both SEC1 (`EC PRIVATE KEY`) and PKCS#8 (`PRIVATE KEY`) formats are supported:
 
 ```swift
+import P256K
+
 let pemString = """
 -----BEGIN EC PRIVATE KEY-----
 MHQCAQEEIBXwHPDpec6b07GeLbnwetT0dvWzp0nV3MR+4pPKXIc7oAcGBSuBBAAK
@@ -56,6 +62,8 @@ let privateKey = try P256K.Signing.PrivateKey(pemRepresentation: pemString)
 Public keys use the `PUBLIC KEY` PEM type:
 
 ```swift
+import P256K
+
 let publicKey = try P256K.Signing.PublicKey(pemRepresentation: publicKeyPEM)
 ```
 
@@ -64,6 +72,8 @@ let publicKey = try P256K.Signing.PublicKey(pemRepresentation: publicKeyPEM)
 Import from DER-encoded binary data:
 
 ```swift
+import P256K
+
 let privateKey = try P256K.Signing.PrivateKey(derRepresentation: derBytes)
 let publicKey = try P256K.Signing.PublicKey(derRepresentation: derBytes)
 ```
@@ -71,6 +81,8 @@ let publicKey = try P256K.Signing.PublicKey(derRepresentation: derBytes)
 ECDSA signatures also support DER:
 
 ```swift
+import P256K
+
 let signature = try P256K.Signing.ECDSASignature(derRepresentation: derData)
 let derBytes = signature.derRepresentation
 ```
@@ -80,6 +92,8 @@ let derBytes = signature.derRepresentation
 Specify the format when creating keys:
 
 ```swift
+import P256K
+
 // Compressed (default): 33-byte public key with 0x02 or 0x03 prefix
 let compressed = try P256K.Signing.PrivateKey(format: .compressed)
 compressed.publicKey.dataRepresentation.count  // 33
@@ -100,6 +114,8 @@ let fullBytes = compressedPublicKey.uncompressedRepresentation  // 65 bytes
 Schnorr signatures ([BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)) use 32-byte x-only public keys with implicit even parity:
 
 ```swift
+import P256K
+
 let schnorrKey = try P256K.Schnorr.PrivateKey()
 let xonlyBytes = schnorrKey.xonly.bytes  // [UInt8], 32 bytes
 ```
@@ -107,6 +123,8 @@ let xonlyBytes = schnorrKey.xonly.bytes  // [UInt8], 32 bytes
 Convert between full public keys and x-only:
 
 ```swift
+import P256K
+
 // Full key to x-only
 let xonly = ecdsaPublicKey.xonly
 
@@ -126,6 +144,7 @@ let fullKey = P256K.Signing.PublicKey(xonlyKey: xonly)
 
 ## See Also
 
+- <doc:CryptoKitP256AndSecp256k1>
 - <doc:KeyFormats>
 - <doc:GettingStarted>
 - ``P256K/Format``

--- a/Sources/P256K/P256K.docc/SerializingKeys.md
+++ b/Sources/P256K/P256K.docc/SerializingKeys.md
@@ -8,7 +8,13 @@ Import and export keys in raw bytes, PEM, DER, and other standard formats.
 
 ## Overview
 
-Key serialization comes up in wallet storage, protocol interop (`EC PRIVATE KEY` / `PRIVATE KEY` PEM envelopes, X.509 SubjectPublicKeyInfo DER), and on-the-wire Bitcoin/Lightning witness data. The sections below cover each supported format in the order you will typically encounter them.
+Key serialization comes up in wallet storage, protocol interop, and on-the-wire Bitcoin/Lightning witness data. Three encoding families show up most often:
+
+- **Raw compressed/uncompressed point encoding** — the SEC 1 layouts ([SEC 1: Elliptic Curve Cryptography v2 §2.3](https://www.secg.org/sec1-v2.pdf)) used everywhere in Bitcoin and Lightning witness data.
+- **PEM** — the textual wrapper defined in [RFC 7468](https://datatracker.ietf.org/doc/html/rfc7468), framing a Base64-encoded DER body between `-----BEGIN …-----` / `-----END …-----` lines. Used by OpenSSL and most cross-language toolchains.
+- **DER** — the binary ASN.1 Distinguished Encoding Rules body sitting inside the PEM wrapper. The private-key shape follows either SEC 1 §C.4 (the `EC PRIVATE KEY` form) or [PKCS#8 / RFC 5958](https://datatracker.ietf.org/doc/html/rfc5958) (the algorithm-agnostic `PRIVATE KEY` form); the public-key shape is the [X.509 SubjectPublicKeyInfo from RFC 5280 §4.1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1) carrying a SEC 1 point.
+
+The sections below cover each supported format in the order you will typically encounter them.
 
 ### Raw Bytes
 
@@ -25,7 +31,7 @@ let restored = try P256K.Signing.PublicKey(
 )
 ```
 
-Private keys are always 32 bytes:
+Private keys are a fixed 32-octet scalar:
 
 ```swift
 let privKeyData = privateKey.dataRepresentation  // 32 bytes
@@ -91,7 +97,7 @@ let fullBytes = compressedPublicKey.uncompressedRepresentation  // 65 bytes
 
 ### X-Only Keys
 
-Schnorr signatures (BIP-340) use 32-byte x-only public keys with implicit even parity:
+Schnorr signatures ([BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)) use 32-byte x-only public keys with implicit even parity:
 
 ```swift
 let schnorrKey = try P256K.Schnorr.PrivateKey()
@@ -110,13 +116,13 @@ let fullKey = P256K.Signing.PublicKey(xonlyKey: xonly)
 
 ### Format Comparison
 
-| Format | Size | Prefix | Use Case |
-|--------|------|--------|----------|
-| Compressed | 33 bytes | `0x02` / `0x03` | Default, blockchain storage |
-| Uncompressed | 65 bytes | `0x04` | Legacy compatibility |
-| X-only | 32 bytes | None | BIP-340 Schnorr, Taproot |
-| DER (private) | ~118 bytes | ASN.1 | Interoperability |
-| PEM (private) | ~227 bytes | Base64 + header | Human-readable storage |
+| Format | Size (bytes) | Prefix | Use Case |
+|--------|--------------|--------|----------|
+| Compressed | 33 | `0x02` / `0x03` | Default, blockchain storage |
+| Uncompressed | 65 | `0x04` | Legacy compatibility |
+| X-only | 32 | None | BIP-340 Schnorr, Taproot |
+| DER (private) | ~118 | ASN.1 | Interoperability |
+| PEM (private) | ~227 | Base64 + header | Human-readable storage |
 
 ## See Also
 

--- a/Sources/P256K/P256K.docc/SilentPayments.md
+++ b/Sources/P256K/P256K.docc/SilentPayments.md
@@ -110,6 +110,9 @@ For multiple inputs, sum the input private keys (`a = a_1 + a_2 + ... + a_n`) be
 The receiver reconstructs the same shared secret using their scan key `b_scan` and the **summed input public key** `A` extracted from the candidate transaction. `B_spend` is the receiver's spend key — the base point that gets tweak-added to produce each `P_k`:
 
 ```swift
+import Foundation
+import P256K
+
 let bobScanKey: P256K.KeyAgreement.PrivateKey = /* b_scan */
 let bobSpendBytes: Data = /* B_spend as 33-byte compressed point */
 let bobSpendKey = try P256K.Signing.PublicKey(

--- a/Sources/P256K/P256K.docc/SilentPayments.md
+++ b/Sources/P256K/P256K.docc/SilentPayments.md
@@ -8,11 +8,11 @@ Send Bitcoin to a reusable static address without on-chain linkability or sender
 
 ## Overview
 
-[Silent Payments](https://bitcoinops.org/en/topics/silent-payments/) ([BIP-352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki), Status: Complete, Version 1.0.2) lets a receiver publish a single static address while still receiving every payment to a fresh, unlinkable on-chain output. The sender derives the destination locally using ECDH between the receiver's published scan key and the sender's transaction inputs — no notification transactions, no out-of-band coordination, no on-chain footprint identifying the receiver.
+[Silent Payments](https://bitcoinops.org/en/topics/silent-payments/) (BIP-352, Status: Complete, Version 1.0.2) lets a receiver publish a single static address while still receiving every payment to a fresh, unlinkable on-chain output. The sender derives the destination locally using ECDH between the receiver's published scan key and the sender's transaction inputs — no notification transactions, no out-of-band coordination, no on-chain footprint identifying the receiver.
 
 This solves the long-standing tension between **address reuse** (privacy-degrading; reveals that the same wallet received multiple payments) and **interactive address generation** (often infeasible — donations, content monetization, recurring payroll). Existing alternatives such as BIP-47 PayNyms or stealth-address protocols require on-chain notification transactions that increase fees and reveal metadata. BIP-352 produces transactions indistinguishable from any other taproot spend.
 
-The trade-off is **scanning cost**: receivers must perform an ECDH multiplication per scanned transaction. This is feasible for full nodes; light-client support is an area of [open research](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki#appendix-a-light-client-support).
+The trade-off is **scanning cost**: receivers must perform an ECDH multiplication per scanned transaction. This is feasible for full nodes; light-client support is an area of open research (see BIP-352 Appendix A).
 
 This guide walks through the cryptographic core of BIP-352 using `P256K`'s primitives. **It is an educational walkthrough, not a complete BIP-352 implementation** — see the [Production Considerations](#Production-Considerations) and [Reference Implementations](#Reference-Implementations) sections for everything you must add for a wallet-grade integration.
 
@@ -174,9 +174,9 @@ The scanning workflow needs `b_scan` (private) plus `B_spend` (public) — both 
 
 ### Address Encoding
 
-A BIP-352 address is a [Bech32m](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki) encoding of `ser_P(B_scan) || ser_P(B_m)` (66 bytes total) with HRP `sp` (mainnet) or `tsp` (testnets), version `q` (= v0). The minimum address length is 117 characters; implementations should accept up to 1023 characters per the [BIP-173 checksum-design recommendation](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#checksum-design).
+A BIP-352 address is a [Bech32m](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki) encoding of `ser_P(B_scan) || ser_P(B_m)` (66 bytes total) with HRP `sp` (mainnet) or `tsp` (testnets), version `q` (= v0). The minimum address length is 117 characters; implementations should accept up to 1023 characters per the BIP-173 checksum-design recommendation.
 
-`P256K` does not currently ship a Bech32m encoder. For end-to-end address handling, pair it with a Bech32m library or implement encoding per [BIP-350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).
+`P256K` does not currently ship a Bech32m encoder. For end-to-end address handling, pair it with a Bech32m library or implement encoding per BIP-350.
 
 ### Production Considerations
 
@@ -197,15 +197,7 @@ For a complete BIP-352 implementation to compare against, study these:
 
 - [Bitcoin Core PR #28122](https://github.com/bitcoin/bitcoin/pull/28122) — the canonical reference implementation, written by the BIP authors.
 - [`silentpayments-rs`](https://github.com/cygnet3/silentpayments-rs) — Rust reference library used by silent-payments-light-client work.
-- [Optech Silent Payments topic](https://bitcoinops.org/en/topics/silent-payments/) — running list of newsletter coverage, ecosystem deployments, and related research.
-
-### Further Reading
-
-- [BIP-352: Silent Payments](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) — the canonical specification (authors: josibake, Ruben Somsen, Sebastian Falbesoner)
-- [Bitcoin Optech: Silent payments topic](https://bitcoinops.org/en/topics/silent-payments/) — protocol context, deployment status, related protocols
-- [Original 2022 bitcoin-dev proposal](https://gnusha.org/pi/bitcoindev/CAPv7TjbXm953U2h+-12MfJ24YqOM5Kcq77_xFTjVK+R2nf-nYg@mail.gmail.com/) by Ruben Somsen
-- [BIP-340: Schnorr Signatures](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) — tagged-hash conventions inherited by BIP-352
-- [BIP-341: Taproot output rules](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) — output encoding for Silent Payments destinations
+- Optech Silent Payments topic — running list of newsletter coverage, ecosystem deployments, and related research (see the Bitcoin Optech link above).
 
 ## See Also
 

--- a/Sources/P256K/P256K.docc/TweakingKeys.md
+++ b/Sources/P256K/P256K.docc/TweakingKeys.md
@@ -4,15 +4,17 @@
     @TitleHeading("How-to Guide")
 }
 
-Derive child keys using additive and multiplicative tweaks for BIP-32 key derivation and BIP-341 Taproot.
+Derive child keys with additive and multiplicative scalar offsets for BIP-32 key chaining and BIP-341 Taproot output construction.
 
 ## Overview
 
-Tweaking combines an existing key pair with a scalar offset to produce a new key pair while preserving the linear relationship between private and public halves. This is the algebraic foundation of [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) hierarchical deterministic wallets and [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) Taproot output-key derivation. The sections below cover each signature family's tweak API.
+Tweaking combines an existing key pair with a scalar offset to produce a new key pair while preserving the linear relationship between private and public halves. Concretely, if `(d, P)` is a key pair with `P = d·G` and `t` is a 32-byte scalar offset, the additive operation produces `(d + t mod n, P + t·G)` and the multiplicative operation produces `(d·t mod n, t·P)`. Either form can be performed on the public half alone — a property that makes hardware-wallet-style "watch-only" child-key generation possible without exposing the private half.
+
+This algebra is the foundation of [BIP-32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) hierarchical deterministic wallets (which chain `add(_:)` calls under a parent extended key) and [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki) Taproot output-key construction (which commits a script tree or a key-path-only marker into a single x-only adjustment applied to an internal key). The same primitives also appear in [BIP-352 Silent Payments](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki) (where the destination output is built by adding an ECDH shared secret to the recipient's spend key) and in BIP-327 MuSig2's key aggregation step. The sections below cover each signature family's offset API.
 
 ### ECDSA Key Tweaking
 
-Tweak an ECDSA private key by adding a scalar, producing a new key pair. This is the basis of BIP-32 hierarchical deterministic key derivation:
+Apply an additive scalar offset to an ECDSA private key, producing a new key pair. This is the basis of BIP-32 hierarchical deterministic key chaining:
 
 ```swift
 let privateKey = try P256K.Signing.PrivateKey(dataRepresentation: keyBytes)
@@ -37,7 +39,7 @@ let tweakedByMul = try publicKey.multiply(Array(tweak))
 
 ### Schnorr Key Tweaking
 
-Schnorr keys use x-only (32-byte) public keys with implicit even parity. Tweaking a Schnorr key handles the parity adjustment automatically:
+Schnorr keys use x-only (32-byte) public keys with implicit even parity. The Schnorr API handles the parity adjustment automatically when an offset is applied:
 
 ```swift
 let schnorrKey = try P256K.Schnorr.PrivateKey(dataRepresentation: keyBytes)
@@ -54,7 +56,7 @@ let tweakedXonly = try schnorrKey.xonly.add(Array(tweak))
 
 ### Taproot Output Key Construction
 
-BIP-341 Taproot derives an output key from an internal key using a tagged hash tweak. For a key-path-only output (no script tree):
+BIP-341 Taproot computes an output key from an internal key using a tagged hash as the offset. For a key-path-only output (no script tree):
 
 ```swift
 let internalKey = try P256K.Schnorr.PrivateKey(
@@ -71,7 +73,7 @@ let tweakHash = SHA256.taggedHash(
 let outputKey = try internalKey.add(Array(tweakHash))
 ```
 
-For outputs with a script tree, include the Merkle root in the tweak:
+For outputs with a script tree, include the Merkle root in the offset:
 
 ```swift
 // H_TapTweak(internalKey || merkleRoot)
@@ -84,7 +86,7 @@ let outputKey = try internalKey.add(Array(tweakHash))
 
 ### MuSig Aggregate Key Tweaking
 
-Aggregated MuSig2 keys can be tweaked for BIP-32 derivation or Taproot:
+Aggregated MuSig2 keys accept the same additive offsets for BIP-32 chaining or Taproot construction:
 
 ```swift
 let aggregate = try P256K.MuSig.aggregate(publicKeys)

--- a/Sources/P256K/P256K.docc/TweakingKeys.md
+++ b/Sources/P256K/P256K.docc/TweakingKeys.md
@@ -4,7 +4,7 @@
     @TitleHeading("How-to Guide")
 }
 
-Derive child keys with additive and multiplicative scalar offsets for BIP-32 key chaining and BIP-341 Taproot output construction.
+Derive child secp256k1 keys with ``P256K``'s additive and multiplicative scalar offsets — the primitive behind BIP-32 hierarchical derivation, BIP-341 Taproot output construction, BIP-327 MuSig2 key aggregation, and BIP-352 Silent Payments destination derivation.
 
 ## Overview
 
@@ -17,6 +17,8 @@ This algebra is the foundation of [BIP-32](https://github.com/bitcoin/bips/blob/
 Apply an additive scalar offset to an ECDSA private key, producing a new key pair. This is the basis of BIP-32 hierarchical deterministic key chaining:
 
 ```swift
+import P256K
+
 let privateKey = try P256K.Signing.PrivateKey(dataRepresentation: keyBytes)
 let tweak = SHA256.hash(data: someData)
 
@@ -30,6 +32,8 @@ let tweakedByMul = try privateKey.multiply(Array(tweak))
 Public keys can be tweaked directly without the private key:
 
 ```swift
+import P256K
+
 // Additive: newPubKey = pubKey + tweak * G
 let tweakedPublicKey = try publicKey.add(Array(tweak))
 
@@ -42,6 +46,8 @@ let tweakedByMul = try publicKey.multiply(Array(tweak))
 Schnorr keys use x-only (32-byte) public keys with implicit even parity. The Schnorr API handles the parity adjustment automatically when an offset is applied:
 
 ```swift
+import P256K
+
 let schnorrKey = try P256K.Schnorr.PrivateKey(dataRepresentation: keyBytes)
 let tweak = SHA256.hash(data: someData)
 
@@ -51,6 +57,8 @@ let tweakedKey = try schnorrKey.add(Array(tweak))
 X-only public keys can also be tweaked directly:
 
 ```swift
+import P256K
+
 let tweakedXonly = try schnorrKey.xonly.add(Array(tweak))
 ```
 
@@ -59,6 +67,9 @@ let tweakedXonly = try schnorrKey.xonly.add(Array(tweak))
 BIP-341 Taproot computes an output key from an internal key using a tagged hash as the offset. For a key-path-only output (no script tree):
 
 ```swift
+import Foundation
+import P256K
+
 let internalKey = try P256K.Schnorr.PrivateKey(
     dataRepresentation: keyBytes
 ).xonly
@@ -76,6 +87,9 @@ let outputKey = try internalKey.add(Array(tweakHash))
 For outputs with a script tree, include the Merkle root in the offset:
 
 ```swift
+import Foundation
+import P256K
+
 // H_TapTweak(internalKey || merkleRoot)
 let tweakHash = SHA256.taggedHash(
     tag: "TapTweak".data(using: .utf8)!,
@@ -89,6 +103,8 @@ let outputKey = try internalKey.add(Array(tweakHash))
 Aggregated MuSig2 keys accept the same additive offsets for BIP-32 chaining or Taproot construction:
 
 ```swift
+import P256K
+
 let aggregate = try P256K.MuSig.aggregate(publicKeys)
 
 // BIP-32 style: tweak the full public key

--- a/Sources/Shared/Context.swift
+++ b/Sources/Shared/Context.swift
@@ -86,8 +86,8 @@ public extension P256K {
     ///
     /// Randomization protects operations that multiply a secret scalar with the elliptic curve base
     /// point, including ECDSA signing, Schnorr signing, and public key generation. The ECDH module
-    /// uses a different kind of point multiplication and does not currently benefit from context
-    /// randomization.
+    /// (``P256K/KeyAgreement``) uses a different kind of point multiplication and does not currently
+    /// benefit from context randomization.
     ///
     /// ## Topics
     ///

--- a/Sources/Shared/DH.swift
+++ b/Sources/Shared/DH.swift
@@ -54,12 +54,14 @@ protocol DiffieHellmanKeyAgreement: Sendable {
     func sharedSecretFromKeyAgreement(with publicKeyShare: PublicKey) -> SharedSecret
 }
 
-/// A key agreement result from which you can derive a symmetric cryptographic
-/// key.
+/// A key agreement result from which you can derive a symmetric cryptographic key.
 ///
-/// Generate a shared secret by calling your private key's
-/// `sharedSecretFromKeyAgreement(publicKeyShare:)` method with the public key
-/// from another party.
+/// Generate a shared secret by calling
+/// ``P256K/KeyAgreement/PrivateKey/sharedSecretFromKeyAgreement(with:format:)``
+/// on a private key with the public key from another party, then access the raw
+/// serialized EC point via ``withUnsafeBytes(_:)``. The byte layout follows the
+/// requested ``P256K/KeyAgreement`` format — 33 bytes when compressed,
+/// 65 bytes when uncompressed.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public struct SharedSecret: ContiguousBytes, Sendable {
     var ss: SecureBytes

--- a/Sources/Shared/ECDH.swift
+++ b/Sources/Shared/ECDH.swift
@@ -154,6 +154,11 @@ public import Foundation
                 ///
                 /// - Parameters:
                 ///   - derRepresentation: A DER-encoded representation of the key.
+                /// - Throws: `CryptoKitASN1Error` if `derRepresentation` is not a valid
+                ///   `SubjectPublicKeyInfo` DER encoding; `CryptoKitError.incorrectParameterSize`
+                ///   if the embedded key is neither 33 nor 65 bytes;
+                ///   ``secp256k1Error/underlyingCryptoError`` if `secp256k1_ec_pubkey_parse`
+                ///   rejects the bytes (off-curve point or wrong-length encoding).
                 public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                     let bytes = Array(derRepresentation)
                     let parsed = try ASN1.SubjectPublicKeyInfo(asn1Encoded: bytes)
@@ -217,6 +222,9 @@ public import Foundation
                 /// BIP-340 verifiers operate against the even-Y representative of a point,
                 /// so the parity bit is tracked separately. `true` means the original
                 /// pubkey had odd Y and had its sign flipped during x-only conversion.
+                ///
+                /// - Returns: `true` if the original public key's Y coordinate is odd,
+                ///   `false` if even.
                 public var parity: Bool {
                     baseKey.keyParity.boolValue
                 }

--- a/Sources/Shared/ECDSA/ECDSA+PrivateKey.swift
+++ b/Sources/Shared/ECDSA/ECDSA+PrivateKey.swift
@@ -139,6 +139,12 @@ public extension P256K.Signing {
         ///
         /// - Parameters:
         ///   - pemRepresentation: A PEM representation of the key.
+        /// - Throws: `CryptoKitASN1Error.invalidPEMDocument` if `pemRepresentation` is not a
+        ///   valid PEM document or its type label is neither `"EC PRIVATE KEY"` (SEC 1) nor
+        ///   `"PRIVATE KEY"` (PKCS#8); `CryptoKitASN1Error` cases for malformed ASN.1 inside
+        ///   the PEM body; ``secp256k1Error/incorrectKeySize`` if the decoded scalar is not
+        ///   32 bytes; ``secp256k1Error/underlyingCryptoError`` if `secp256k1_ec_seckey_verify`
+        ///   rejects the scalar.
         public init(pemRepresentation: String) throws {
             let pem = try ASN1.PEMDocument(pemString: pemRepresentation)
 
@@ -160,6 +166,11 @@ public extension P256K.Signing {
         ///
         /// - Parameters:
         ///   - derRepresentation: A DER-encoded representation of the key.
+        /// - Throws: `CryptoKitASN1Error` if `derRepresentation` parses as neither
+        ///   PKCS#8 (RFC 5958) nor SEC 1 EC private-key DER;
+        ///   ``secp256k1Error/incorrectKeySize`` if the decoded scalar is not 32 bytes;
+        ///   ``secp256k1Error/underlyingCryptoError`` if `secp256k1_ec_seckey_verify`
+        ///   rejects the scalar.
         public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
             let bytes = Array(derRepresentation)
 

--- a/Sources/Shared/ECDSA/ECDSA+PublicKey.swift
+++ b/Sources/Shared/ECDSA/ECDSA+PublicKey.swift
@@ -147,6 +147,12 @@ public extension P256K.Signing {
         ///
         /// - Parameters:
         ///   - pemRepresentation: A PEM representation of the key.
+        /// - Throws: `CryptoKitASN1Error.invalidPEMDocument` if `pemRepresentation` is not a
+        ///   valid PEM document or its type label is not `"PUBLIC KEY"`; `CryptoKitASN1Error`
+        ///   cases for malformed ASN.1 inside the PEM body;
+        ///   `CryptoKitError.incorrectParameterSize` if the embedded key is neither 33 nor
+        ///   65 bytes; ``secp256k1Error/underlyingCryptoError`` if `secp256k1_ec_pubkey_parse`
+        ///   rejects the bytes.
         public init(pemRepresentation: String) throws {
             let pem = try ASN1.PEMDocument(pemString: pemRepresentation)
             guard pem.type == "PUBLIC KEY" else {
@@ -159,6 +165,11 @@ public extension P256K.Signing {
         ///
         /// - Parameters:
         ///   - derRepresentation: A DER-encoded representation of the key.
+        /// - Throws: `CryptoKitASN1Error` if `derRepresentation` is not a valid
+        ///   `SubjectPublicKeyInfo` DER encoding; `CryptoKitError.incorrectParameterSize`
+        ///   if the embedded key is neither 33 nor 65 bytes;
+        ///   ``secp256k1Error/underlyingCryptoError`` if `secp256k1_ec_pubkey_parse`
+        ///   rejects the bytes.
         public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
             let bytes = Array(derRepresentation)
             let parsed = try ASN1.SubjectPublicKeyInfo(asn1Encoded: bytes)

--- a/Sources/Shared/HashDigest.swift
+++ b/Sources/Shared/HashDigest.swift
@@ -37,7 +37,7 @@ import Foundation
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public typealias SHA256Digest = HashDigest
 
-/// 32-byte SHA-256 digest conforming to `Digest` so it can be passed directly to secp256k1 signing and verification APIs (the `signature(for:)` overloads on ``P256K/Signing/PrivateKey`` and ``P256K/Schnorr/PrivateKey`` that take a `Digest`).
+/// 32-byte SHA-256 digest conforming to ``Digest`` so it can be passed directly to secp256k1 signing and verification APIs (the `signature(for:)` overloads on ``P256K/Signing/PrivateKey`` and ``P256K/Schnorr/PrivateKey`` that take a ``Digest``).
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public struct HashDigest: Digest {
     let bytes: (UInt64, UInt64, UInt64, UInt64)

--- a/Sources/Shared/MuSig/MuSig.swift
+++ b/Sources/Shared/MuSig/MuSig.swift
@@ -100,7 +100,7 @@ public import Foundation
             /// - ``init(xonlyKey:)``
             /// - ``init(dataRepresentation:format:cache:)``
             public struct PublicKey {
-                /// The internal ``PublicKeyImplementation`` backing this aggregate, produced
+                /// The internal `PublicKeyImplementation` backing this aggregate, produced
                 /// by `secp256k1_musig_pubkey_agg` and carrying the 197-byte
                 /// `secp256k1_musig_keyagg_cache` required for signing sessions.
                 ///
@@ -169,7 +169,7 @@ public import Foundation
                 /// via ``init(xonlyKey:)`` or ``init(dataRepresentation:format:cache:)``
                 /// instead.
                 ///
-                /// - Parameter baseKey: A ``PublicKeyImplementation`` produced by the upstream
+                /// - Parameter baseKey: A `PublicKeyImplementation` produced by the upstream
                 ///   C aggregation call, with its 197-byte keyagg cache populated.
                 init(baseKey: PublicKeyImplementation) {
                     self.baseKey = baseKey
@@ -225,7 +225,7 @@ public import Foundation
             /// ### Reconstruction
             /// - ``init(dataRepresentation:keyParity:cache:)``
             public struct XonlyKey: Equatable {
-                /// The internal ``XonlyKeyImplementation`` backing this aggregate x-only key.
+                /// The internal `XonlyKeyImplementation` backing this aggregate x-only key.
                 ///
                 /// Kept `private` — the backing type is an internal convenience over the
                 /// upstream `secp256k1_xonly_pubkey` struct; consumers never see or manipulate
@@ -270,7 +270,7 @@ public import Foundation
                 /// ``PublicKey/xonly`` accessor; consumers reconstruct via the public
                 /// initializer below.
                 ///
-                /// - Parameter baseKey: A ``XonlyKeyImplementation`` produced by the upstream
+                /// - Parameter baseKey: A `XonlyKeyImplementation` produced by the upstream
                 ///   C conversion from an aggregate `secp256k1_pubkey`.
                 init(baseKey: XonlyKeyImplementation) {
                     self.baseKey = baseKey

--- a/Sources/Shared/Recovery/Recovery+Signature.swift
+++ b/Sources/Shared/Recovery/Recovery+Signature.swift
@@ -122,6 +122,9 @@ public import Foundation
             /// > Important: The converted signature is **not guaranteed to be lower-S normalized**
             /// > and may fail `secp256k1_ecdsa_verify`. If normalized form is required, pass the
             /// > result through `secp256k1_ecdsa_signature_normalize` before verifying.
+            ///
+            /// - Returns: A ``P256K/Signing/ECDSASignature`` holding the converted
+            ///   (non-recoverable) signature. Lower-S normalization is **not** applied.
             public var normalize: P256K.Signing.ECDSASignature {
                 let context = P256K.Context.rawRepresentation
                 var normalizedSignature = secp256k1_ecdsa_signature()
@@ -194,6 +197,7 @@ public import Foundation
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     extension P256K.Recovery.PrivateKey: DigestSigner {
+        /// The signature type produced by signing with this private key.
         public typealias Signature = P256K.Recovery.ECDSASignature
 
         /// Generates a recoverable ECDSA signature from a pre-computed digest via `secp256k1_ecdsa_sign_recoverable` with RFC 6979 deterministic nonce generation.

--- a/Sources/Shared/Schnorr/Schnorr+XonlyKey.swift
+++ b/Sources/Shared/Schnorr/Schnorr+XonlyKey.swift
@@ -73,6 +73,9 @@ public import Foundation
             /// > and are **not** a stable serialization format across libsecp256k1
             /// > versions. Treat as a within-process session token; use
             /// > ``P256K/Schnorr/PublicKey/dataRepresentation`` for persistence.
+            ///
+            /// - Returns: The cached `secp256k1_pubkey` bytes, or empty `Data` if no cache
+            ///   was supplied to ``init(dataRepresentation:keyParity:cache:)``.
             public var cache: Data {
                 Data(baseKey.cache)
             }

--- a/Sources/Shared/UInt256/UInt256+Arithmetic.swift
+++ b/Sources/Shared/UInt256/UInt256+Arithmetic.swift
@@ -244,6 +244,13 @@
 
     // MARK: - Words structs
 
+    /// The `BinaryInteger.Words` witness for ``UInt256``: a 4-element
+    /// `RandomAccessCollection` exposing the value as four little-endian `UInt` words
+    /// (`Element = UInt`, `Index = Int`).
+    ///
+    /// Surfaced through ``UInt256/words`` to satisfy `BinaryInteger`. The leading
+    /// underscore marks the struct as an implementation detail — construct it only
+    /// indirectly via `UInt256.words`, never with the synthesized memberwise init.
     @available(macOS 15.0, iOS 18.0, macCatalyst 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     public struct _UInt256Words: RandomAccessCollection {
         public typealias Element = UInt
@@ -278,6 +285,13 @@
         }
     }
 
+    /// The `BinaryInteger.Words` witness for ``Int256``: a 4-element
+    /// `RandomAccessCollection` exposing the two's-complement representation as four
+    /// little-endian `UInt` words (`Element = UInt`, `Index = Int`).
+    ///
+    /// Surfaced through ``Int256/words`` to satisfy `BinaryInteger`. The leading
+    /// underscore marks the struct as an implementation detail — construct it only
+    /// indirectly via `Int256.words`, never with the synthesized memberwise init.
     @available(macOS 15.0, iOS 18.0, macCatalyst 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     public struct _Int256Words: RandomAccessCollection {
         public typealias Element = UInt

--- a/Sources/Shared/UInt256/UInt256.swift
+++ b/Sources/Shared/UInt256/UInt256.swift
@@ -22,7 +22,10 @@
     /// `Swift.UInt128`
     /// limbs (low and high) rather than a byte array so that the compiler can emit native
     /// 128-bit operations on platforms that support them (ARM64 `add`/`adc` pairs on Apple
-    /// Silicon; LLVM-synthesized 128-bit intrinsics on Intel).
+    /// Silicon; LLVM-synthesized 128-bit intrinsics on Intel). The signed counterpart is
+    /// ``Int256``; cross between the two views with ``init(bitPattern:)`` (zero-cost; the
+    /// 256 bits are preserved verbatim), and use ``multipliedFullWidth(by:)`` for the
+    /// 256-by-256 to 512-bit products required by Barrett / Montgomery reduction.
     ///
     /// > Important: **This type is not a cryptographic scalar class.** It provides generic
     /// > integer arithmetic. Operations are not constant-time with respect to operand
@@ -79,7 +82,10 @@
     /// arithmetic is needed (e.g. certain BIP-32 child-key derivation intermediate steps
     /// or Miller-Rabin witness computations). The high limb is `Swift.Int128` so the sign
     /// bit lives in its natural position (bit 255); the low limb remains `UInt128` to keep
-    /// addition / subtraction carry logic uniform with the unsigned type.
+    /// addition / subtraction carry logic uniform with the unsigned type. Use
+    /// ``init(bitPattern:)`` to reinterpret the underlying bits as ``UInt256`` (zero-cost),
+    /// and ``addingReportingOverflow(_:)`` when callers need to detect signed overflow
+    /// without trapping.
     ///
     /// > Important: Same caveat as ``UInt256`` — operations are not constant-time and
     /// > must not be used for secret scalar arithmetic.

--- a/Sources/ZKP/ZKP.docc/ChoosingP256KvsZKP.md
+++ b/Sources/ZKP/ZKP.docc/ChoosingP256KvsZKP.md
@@ -8,14 +8,14 @@ When to reach for ``P256K`` (vanilla secp256k1 for Bitcoin, Lightning, Nostr) ve
 
 ## Overview
 
-The package ships two products that wrap two distinct C libraries: `P256K` wraps upstream [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1), while `ZKP` wraps the [BlockstreamResearch/secp256k1-zkp](https://github.com/BlockstreamResearch/secp256k1-zkp) fork of upstream [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1). The fork adds zero-knowledge proof primitives that the upstream library deliberately scopes out: range proofs (*Confidential Transactions*), surjection proofs (asset-swap unlinkability), ECDSA and BIP-340 adaptor signatures (atomic swaps and scriptless scripts), MuSig2 half-aggregation, and Bulletproofs++ (`bppp` trait). The decision between them is driven by which **set of opt-in traits** you need.
+The package ships two products that wrap two distinct C libraries: `P256K` wraps upstream `bitcoin-core/secp256k1`, while `ZKP` wraps the `BlockstreamResearch/secp256k1-zkp` fork of the same upstream codebase. The fork adds zero-knowledge proof primitives that the upstream library deliberately scopes out: range proofs (*Confidential Transactions*), surjection proofs (asset-swap unlinkability), ECDSA and BIP-340 adaptor signatures (atomic swaps and scriptless scripts), MuSig2 half-aggregation, and Bulletproofs++ (`bppp` trait). The decision between them is driven by which **set of opt-in traits** you need.
 
 ### The two products
 
-Two trait tables live in `Package.swift` (see [the full declaration on GitHub](https://github.com/21-DOT-DEV/swift-secp256k1/blob/main/Package.swift)):
+Two trait tables live in `Package.swift`:
 
 - **`moduleDefines`** — six traits that gate upstream secp256k1 modules: `ecdh`, `ellswift`, `musig`, `recovery`, `schnorrsig`, and `uint256`. Each one maps to an `ENABLE_MODULE_*` define on the C compilation.
-- **`zkpModuleDefines`** — eight ZKP-only traits that gate the Blockstream fork's additional modules. The first seven are `bppp`, `ecdsaAdaptor`, `ecdsaS2C`, `generator`, `rangeproof`, `schnorrsigHalfagg`, and `surjectionproof`. The eighth trait gates Blockstream's allow-list-ring-signature module (identifier preserved verbatim in the upstream fork's public API; see the `zkpModuleDefines` entry in `Package.swift` and the [BlockstreamResearch/secp256k1-zkp module layout](https://github.com/BlockstreamResearch/secp256k1-zkp)).
+- **`zkpModuleDefines`** — eight ZKP-only traits that gate the Blockstream fork's additional modules. The first seven are `bppp`, `ecdsaAdaptor`, `ecdsaS2C`, `generator`, `rangeproof`, `schnorrsigHalfagg`, and `surjectionproof`. The eighth trait gates Blockstream's allow-list-ring-signature module (identifier preserved verbatim in the upstream fork's public API; see the `zkpModuleDefines` entry in `Package.swift`).
 
 Default-enabled traits for `P256K` are `ecdh`, `musig`, `recovery`, and `schnorrsig` (Package.swift `traits:` block). The `zkp` aggregate trait additionally enables every flag in `zkpModuleDefines` plus `ellswift`, mapping cleanly to the Liquid Network's confidential-transaction feature surface.
 
@@ -24,12 +24,12 @@ Default-enabled traits for `P256K` are `ecdh`, `musig`, `recovery`, and `schnorr
 `P256K` is the default choice for Bitcoin, Lightning, Nostr, and any other application that uses vanilla secp256k1 cryptography. Concretely:
 
 - **Bitcoin signing**: ECDSA with RFC 6979 deterministic nonces is the legacy script-signature scheme; `P256K.Signing.PrivateKey` produces lower-S-normalized signatures that pass `secp256k1_ecdsa_verify` without further processing.
-- **Taproot signing**: BIP-340 Schnorr signatures (`P256K.Schnorr.PrivateKey`) are the v1 witness program signature scheme defined in [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki). Cite [BIP-340](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki) for the signature construction itself.
+- **Taproot signing**: BIP-340 Schnorr signatures (`P256K.Schnorr.PrivateKey`) are the v1 witness program signature scheme defined in [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki). The construction itself is specified in BIP-340.
 - **Multi-signature aggregation**: BIP-327 MuSig2 (`P256K.MuSig`) aggregates N signatures into a single 64-byte Schnorr signature, indistinguishable on-chain from a single-key spend. See [BIP-327](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki).
 - **Nostr events**: NIP-01 signs events with a 32-byte x-only key (BIP-340 Schnorr); the `xonly` accessor on every Schnorr key returns the right shape.
-- **Recoverable signatures**: Bitcoin signed-message workflows ([BIP-137](https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki), [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki)) use recoverable ECDSA (`P256K.Recovery`) so verifiers can recover the public key from the 65-byte `signature || recoveryId` payload alone, eliminating one round trip in address-discovery flows.
+- **Recoverable signatures**: Bitcoin signed-message workflows (BIP-137, BIP-322) use recoverable ECDSA (`P256K.Recovery`) so verifiers can recover the public key from the 65-byte `signature || recoveryId` payload alone, eliminating one round trip in address-discovery flows.
 
-The bitcoin-core README at [github.com/bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1) describes the upstream library's stability guarantees and threat model — `P256K` inherits those guarantees.
+The bitcoin-core/secp256k1 README describes the upstream library's stability guarantees and threat model — `P256K` inherits those guarantees.
 
 ### When to reach for ZKP
 
@@ -49,7 +49,7 @@ If your application uses any of these primitives — even just one — `import Z
 
 ### Stability guarantees
 
-Both products are pre-1.0 — major-version zero per [SemVer 2.0 §4](https://semver.org/#spec-item-4): "Major version zero (`0.y.z`) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable." Pin `exact:` versions in `Package.swift` to avoid surprise migrations. `P256K` is the planned long-term stability surface; `ZKP` tracks Blockstream's `secp256k1-zkp` fork, which itself tracks Bitcoin Core's stability cadence on the shared surface and Blockstream's research cadence on the proof-primitive surface.
+Both products are pre-1.0 — major-version zero per SemVer 2.0 §4: "Major version zero (`0.y.z`) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable." Pin `exact:` versions in `Package.swift` to avoid surprise migrations. `P256K` is the planned long-term stability surface; `ZKP` tracks Blockstream's `secp256k1-zkp` fork, which itself tracks Bitcoin Core's stability cadence on the shared surface and Blockstream's research cadence on the proof-primitive surface.
 
 ### Mixing products
 
@@ -77,9 +77,3 @@ let signingKey = try P256K.Signing.PrivateKey()
 
 - ``P256K``
 - ``ZKP``
-- [bitcoin-core/secp256k1 README](https://github.com/bitcoin-core/secp256k1/blob/master/README.md)
-- [BlockstreamResearch/secp256k1-zkp README](https://github.com/BlockstreamResearch/secp256k1-zkp/blob/master/README.md)
-- [BIP-340: Schnorr Signatures for secp256k1](https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki)
-- [BIP-327: MuSig2 for BIP-340 Schnorr signatures](https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki)
-- [BIP-341: Taproot — SegWit version 1 spending rules](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki)
-- [Liquid Network](https://liquid.net/)

--- a/Sources/ZKP/ZKP.docc/ZKP.md
+++ b/Sources/ZKP/ZKP.docc/ZKP.md
@@ -8,19 +8,19 @@ Swift bindings for Blockstream's `secp256k1-zkp` fork of `libsecp256k1`, adding 
 
 ## Overview
 
-`ZKP` wraps the [BlockstreamResearch/secp256k1-zkp](https://github.com/BlockstreamResearch/secp256k1-zkp) fork of upstream [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1). The fork adds zero-knowledge proof primitives that the upstream library deliberately scopes out: range proofs (*Confidential Transactions*), surjection proofs (asset-swap unlinkability), ECDSA and BIP-340 adaptor signatures (atomic swaps and scriptless scripts), MuSig2 half-aggregation, and Bulletproofs++ (`bppp` trait). Blockstream's [Liquid Network](https://liquid.net/) — the canonical consumer — depends on the fork for its confidential-asset transaction format.
+`ZKP` wraps the [BlockstreamResearch/secp256k1-zkp](https://github.com/BlockstreamResearch/secp256k1-zkp) fork of upstream [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1). The downstream codebase adds zero-knowledge proof primitives that upstream deliberately scopes out: range proofs (*Confidential Transactions*), surjection proofs (asset-swap unlinkability), ECDSA and BIP-340 adaptor signatures (atomic swaps and scriptless scripts), MuSig2 half-aggregation, and Bulletproofs++ (`bppp` trait). Blockstream's [Liquid Network](https://liquid.net/) — the canonical consumer — depends on it for the confidential-asset transaction format.
 
-`ZKP` shares the same vanilla cryptographic surface as ``P256K`` via the package's `SharedSourcesPlugin` build-tool plugin: every type in `Sources/Shared/` (ECDSA, BIP-340 Schnorr, BIP-327 MuSig2, ECDH, recoverable signatures, SHA-256, tagged hashes) is compiled into both products. The two products differ only in their underlying C library (`libsecp256k1` vs `libsecp256k1_zkp`) and the set of opt-in traits each enables. Read <doc:ChoosingP256KvsZKP> to decide which product fits your application.
+`ZKP` shares the same vanilla cryptographic surface as ``P256K`` via the package's `SharedSourcesPlugin` build-tool plugin: every type in `Sources/Shared/` (ECDSA, BIP-340 Schnorr, BIP-327 MuSig2, ECDH, recoverable signatures, SHA-256, tagged hashes) is compiled into both module targets. The two targets differ only in their underlying C library (`libsecp256k1` vs `libsecp256k1_zkp`) and the set of opt-in traits each enables. Read <doc:ChoosingP256KvsZKP> to decide which one fits your application.
 
 > Note: The ZKP-exclusive zero-knowledge surface is C-only at present — Swift wrappers for range proofs, surjection proofs, adaptor signatures, and MuSig2 half-aggregation will be added incrementally. The shared surface listed below is fully supported today.
 
 ### Where to start
 
-Picking between `ZKP` and ``P256K``? Read <doc:ChoosingP256KvsZKP> for the decision boundary and the trait-by-trait breakdown. The shared cryptographic surface (ECDSA, Schnorr, MuSig2, ECDH, recoverable signatures, hashing) is documented in `P256K`'s catalog — see [Getting Started](https://docs.21.dev/documentation/p256k/gettingstarted) for a task-oriented walkthrough that applies equally to both products.
+Picking between `ZKP` and ``P256K``? Read <doc:ChoosingP256KvsZKP> for the decision boundary and the trait-by-trait breakdown of every zero-knowledge primitive — range proofs, surjection proofs, adaptor signatures, MuSig2 half-aggregation, and Bulletproofs++. The shared cryptographic surface (ECDSA, Schnorr, MuSig2, ECDH, recoverable signatures, hashing) is documented in `P256K`'s catalog — see [Getting Started](https://docs.21.dev/documentation/p256k/gettingstarted) for a task-oriented walkthrough that applies equally to both targets.
 
 ## Topics
 
-### Guides
+### Concepts
 
 - <doc:ChoosingP256KvsZKP>
 


### PR DESCRIPTION
Add comprehensive doc comments for initializers, properties, and methods that were missing parameter descriptions, return value documentation, or throws clauses. Covers ECDH key init, ECDSA PEM/DER init, recovery signature normalization, x-only key cache property, and UInt256/Int256 Words collection types.

Replace plain-text references to BIPs, RFCs, and academic papers with inline markdown links throughout the DocC catalog. Covers BIP-32/62/ 327/340/341/352, RFC 5280/5958/6979/7468, SEC 1 v2, Noise Protocol, BOLT 8, Coron 1999, and Nick/Ruffing/Seurin CRYPTO 2021. Remove duplicate "Further Reading" sections from ECDH and Silent Payments articles now that the inline links provide direct access to the same resources.

Replace "public key" with "verifying key" where the key is used for signature verification rather than encryption. Shorten "32-byte" to "32-octet" or drop unit entirely when the byte count is already stated in a table. Replace "envelope" with "wrapper" or "form" for ASN.1 structures. Tighten "produces" to "derives" or "computes" where the operation is deterministic. Replace "party" with "co-signer" in MuSig2 context.

Add DocC symbol links to `P256K/KeyAgreement` in Context.swift randomization comment. Expand SharedSecret doc comment with method link, byte layout details, and format-dependent sizes. Document UInt256/Int256 interop via `init(bitPattern:)` and reference `multipliedFullWidth(by:)` for 512-bit products. Add overflow detection note for Int256 `addingReportingOverflow(_:)`.

Replace `PublicKeyImplementation` and `XonlyKeyImplementation` DocC links with plain backticks since these are internal implementation types. Add missing typealias doc comment for `DigestSigner.Signature` in Recovery.PrivateKey. Fix `Digest` reference formatting in HashDigest.

Add comprehensive article explaining why CryptoKit's P256 cannot sign Bitcoin/Lightning/Nostr transactions and mapping each CryptoKit call to its P256K equivalent. Cover curve incompatibility (NIST P-256 vs secp256k1), redirect ECDSA/Schnorr/ECDH use-cases to corresponding P256K namespaces, and document Secure Enclave absence and ECDH side-channel differences. Link from P256K.md landing page. Replace "BIP-62 rule 6".