### PR TITLE
docs: Update roadmap to v2.1.0 for 2026 alignment

### DIFF
--- a/.specify/memory/roadmap.md
+++ b/.specify/memory/roadmap.md
@@ -1,7 +1,7 @@
 # swift-secp256k1 Product Roadmap
 
-**Version**: v2.0.0  
-**Last Updated**: 2026-06-05  
+**Version**: v2.1.0  
+**Last Updated**: 2026-08-01  
 **Constitution**: [constitution.md](constitution.md)
 
 ---
@@ -33,6 +33,7 @@ Build the most reliable, secure, and developer-friendly Swift secp256k1 library 
 | **Module-rename migration & version adoption** | Most downstream consumers are stranded on the legacy `secp256k1` product name and old pins (e.g., 0.12.2, 0.18.0, 0.19.0). Primitives added only to `P256K` cannot reach them. Provide a migration path / compatibility story so new APIs are actually adoptable — the single highest adoption lever. | 🔜 Planned |
 | **swift-crypto 4.2.0 Update** | Update vendored swift-crypto via subtree plugin from 3.11.1 to 4.2.0. Resolve breaking availability attribute changes in `Sources/Shared/` on a case-by-case basis (e.g., `UInt256.swift` retains current attributes due to `StaticBigInt` dependency). | 🔜 Planned |
 | **UInt256 SecurityTests** | Add security test vectors for `UInt256`/`SIMDWordsInteger` to `Projects/Sources/SecurityTests/`: overflow detection, boundary correctness, power-of-two multiply paths, Codable parsing hardening. _(The `SecurityTests` target exists with DER/InvalidCurve/PointValidation/ScalarValidation/SignatureMalleability/ZeroSignature/Nonce coverage; UInt256 vectors are still absent.)_ | 🔜 Planned |
+| **Vendir migration** | Adopt vendir-driven vendoring (the pattern proven in swift-openssl), retiring `subtree.yaml`, the subtree CLI/plugin workflows, and most Dependabot configuration. Scheduled in Q1 of the 2026 funding window (shared 2026 roadmap). | 🔜 Planned |
 
 ---
 
@@ -73,9 +74,12 @@ Phases are **theme-based capability slices**, ordered by **downstream-consumer r
 | **🟡 Next** | 7 | [HD-Wallet & Key Derivation](roadmap/phase-7-hd-wallet-derivation.md) | ★★★★☆ wallets, Nostr (NIP-06), Cashu | 🔜 Planned |
 | | 8 | [Blind Signatures & DLEQ](roadmap/phase-8-blind-signatures-dleq.md) | ★★★☆☆ Cashu | 🔜 Planned |
 | | 9 | [Applications / L2 Showcase](roadmap/phase-9-applications.md) | demo / reference | 🔜 Planned |
+| | 9.5 | [Command-Line Tool](roadmap/phase-9.5-cli-tool.md) | ★★★☆☆ developers, scripting/CI | 🔜 Planned |
 | **⚪ Later** | 10 | [secp256k1-Native Protocols](roadmap/phase-10-native-protocols.md) | ★★★☆☆ Bitcoin advanced | 📋 Future |
 | | 11 | [Forward-looking Signatures](roadmap/phase-11-forward-looking-signatures.md) | ★★☆☆☆ future | 📋 Future |
 | **—** | — | [Backlog](roadmap/backlog.md) | — | 📋 Future |
+
+_Funding note (2026-08-01):_ Phases 3, 8, and 9 sit outside the current 2026 funding window; Phase 9.5 (Q5) and Phase 10's Silent Payments (Q1) are scheduled inside it, per the shared 2026 outreach roadmap.
 
 ### Phase Summaries
 
@@ -89,9 +93,10 @@ Phases are **theme-based capability slices**, ordered by **downstream-consumer r
 - **Phase 7 — HD-Wallet & Key Derivation** — BIP-32 CKD + xpub/xprv serialization, BIP-39 (PBKDF2-SHA512 + wordlist), HASH160/RIPEMD-160 (low). Depends on Phase 5.
 - **Phase 8 — Blind Signatures & DLEQ** — Cashu BDHKE (hash-to-curve, DST `Secp256k1_HashToCurve_Cashu_`) + NUT-12 DLEQ. Re-verify constants before implementing.
 - **Phase 9 — Applications / L2 Showcase** — MuSig2 SwiftUI app re-aimed at L2 (ARK/Cube covenant signing, Lightning PTLC) + NIP-19 / BIP-137 samples.
+- **Phase 9.5 — Command-Line Tool** — key generation, signing, verification, and address/npub encoding in the terminal; Homebrew distribution. Promoted from the backlog for the 2026 funding window.
 - **Phase 10 — secp256k1-Native Protocols** — Silent Payments (BIP-352), ellswift / BIP-324 v2 transport.
 - **Phase 11 — Forward-looking Signatures** — FROST threshold (draft), Schnorr half-aggregation.
-- **Backlog** — Data structures (Bloom/Golomb/Merkle), CLI apps, niche primitives, Windows support.
+- **Backlog** — Data structures (Bloom/Golomb/Merkle), niche primitives, Windows support.
 
 ---
 
@@ -133,6 +138,7 @@ Priorities are informed by how downstream apps and libraries actually use the pa
 - **Phase 5 (SHA-2 Tower)** enables **Phase 7 (HD-Wallet)** (HMAC-SHA512/PBKDF2) and feeds **Phase 8 (DLEQ uses SHA-256)**.
 - **Phase 4 (Encodings)** feeds **Phase 7** (Base58Check for xpub/xprv) and **Phase 9** (address/invoice display).
 - **Phase 6 (Adaptor sigs)** enables **Phase 9** (PTLC demo) and the L2 strategy.
+- **Phase 9.5 (CLI)** depends on **Phase 4** (address/npub encodings); MuSig2 ceremony mode rides shipped MuSig2.
 - **Phase 2 (CI)** + **Phase 3 (Docs)** are continuous enabler tracks that overlap everything.
 - **Zone-D primitives** (ChaCha20, scrypt, AES, SHA-3) are **not** roadmap items — they come from swift-openssl (see Package Separation).
 
@@ -167,3 +173,4 @@ Priorities are informed by how downstream apps and libraries actually use the pa
 | v1.7.0 | 2026-06-05 | Researched | Deep-research pass 1 (Bitcoin/L2): EC-signature layer confirmed complete; corrected 3 errors (adaptor sigs vendored-C-only; Sphinx = HMAC-SHA256 not HKDF; tagged-hash partial) |
 | v1.8.0 | 2026-06-05 | Researched | Deep-research pass 2 (Nostr/Cashu): NIP-44 exact construction, NIP-19 Bech32/TLV, Cashu BDHKE + NUT-12 DLEQ; corrected NIP-44 to bare ChaCha20 (not Poly1305 AEAD) |
 | **v2.0.0** | **2026-06-05** | **Restructured** | Re-architected into **12 demand-ordered, theme-based phases on Now/Next/Later horizons** (RICE/WSJF by downstream reach); added the centralized **Package Separation (swift-secp256k1 ↔ swift-openssl)** section (Zone A–D + priority/fallback rule); promoted ZKP-tier / BDHKE / Silent-Payments / ellswift / BIP-32-serialization from backlog to first-class phases; **folded the standalone `downstream-demand.md` + `foundational-toolkit-research.md` into this fileset (distilled) and removed them**; resolved ChaCha20 → sourced from swift-openssl (NIP-44 = composition) |
+| **v2.1.0** | **2026-08-01** | **MINOR** | 2026 funding-round alignment (shared 2026 outreach roadmap): promoted the CLI from backlog to **Phase 9.5** (scheduled Q5); added the **vendir migration** high-priority item (Q1); funding-window annotations — Phases 3/8/9 outside, Phase 10 Silent Payments pulled in (Q1) |

--- a/.specify/memory/roadmap/backlog.md
+++ b/.specify/memory/roadmap/backlog.md
@@ -42,14 +42,7 @@ General-purpose structures supporting specific BIPs (in-repo vs recommend-extern
 
 ## Deferred applications (CLIs)
 
-Complement the Phase 9 SwiftUI app:
-
-| App | Notes | Priority |
-|-----|-------|----------|
-| MuSig2 CLI | Command-line ceremony for scripting | Medium |
-| Address Generator | Key → address (Phase 4 Bech32) | Medium |
-| ECDSA Signing CLI | Basic signing/verification | Low |
-| Schnorr Verifier | Standalone verification utility | Low |
+**Promoted 2026-08-01**: the CLI tools (MuSig2 CLI, address generator, ECDSA signing CLI, Schnorr verifier) were promoted from this backlog to **Phase 9.5 — Command-Line Tool** for the 2026 funding window (Q5 of the shared 2026 roadmap). See [phase-9.5-cli-tool.md](phase-9.5-cli-tool.md).
 
 ---
 

--- a/.specify/memory/roadmap/phase-10-native-protocols.md
+++ b/.specify/memory/roadmap/phase-10-native-protocols.md
@@ -3,6 +3,7 @@
 **Goal**: secp256k1-native protocol-level capabilities that are pure EC but go beyond single primitives  
 **Horizon**: ⚪ Later  
 **Status**: 📋 Future  
+**Funding**: Silent Payments pulled into the 2026 funding window (Q1 of the shared 2026 roadmap); ellswift / BIP-324 transport remains ⚪ Later  
 **Reach**: ★★★☆☆ — Bitcoin advanced  
 **Depends On**: Phase 4 (encodings), EC ops (shipped)  
 **Last Updated**: 2026-06-05

--- a/.specify/memory/roadmap/phase-3-documentation-dx.md
+++ b/.specify/memory/roadmap/phase-3-documentation-dx.md
@@ -3,6 +3,7 @@
 **Goal**: Enable adoption through comprehensive documentation, tutorials, and improved API ergonomics  
 **Horizon**: 🔵 Now (continuous enabler)  
 **Status**: 🚧 In Progress  
+**Funding**: Outside the 2026 funding window (ongoing, unfunded)  
 **Last Updated**: 2026-06-05  
 **Depends On**: Phase 2 (CI & Quality Gates) — can partially overlap  
 **Blocks**: Phase 9 (apps need documented APIs)

--- a/.specify/memory/roadmap/phase-8-blind-signatures-dleq.md
+++ b/.specify/memory/roadmap/phase-8-blind-signatures-dleq.md
@@ -3,6 +3,7 @@
 **Goal**: Cashu's blind Diffie-Hellman key exchange (BDHKE) and NUT-12 discrete-log-equality proofs — secp256k1-native, for the ecash cohort  
 **Horizon**: 🟡 Next  
 **Status**: 🔜 Planned  
+**Funding**: Outside the 2026 funding window  
 **Reach**: ★★★☆☆ — Cashu (CashuSwift, macadamia, bitpoints, nutsack, CashuKit); every lib reimplements BDHKE  
 **Depends On**: SHA-256 + point ops (shipped); hash-to-curve  
 **Last Updated**: 2026-06-05

--- a/.specify/memory/roadmap/phase-9-applications.md
+++ b/.specify/memory/roadmap/phase-9-applications.md
@@ -3,6 +3,7 @@
 **Goal**: Demonstrate the library through Bitcoin-Layer-2-focused apps and reference samples that double as integration tests  
 **Horizon**: 🟡 Next  
 **Status**: 🔜 Planned  
+**Funding**: Outside the 2026 funding window  
 **Reach**: demo / reference (reduces the "everyone hand-rolls it" tax)  
 **Depends On**: Phase 6 (adaptor sigs), Phase 4 (encodings)  
 **Last Updated**: 2026-06-05
@@ -53,7 +54,7 @@ The things consumers currently hand-roll — each a small, copy-pasteable sample
 
 ## Backlog (future apps)
 
-CLI tools deferred to [backlog.md](backlog.md): MuSig2 CLI, ECDSA signing CLI, Schnorr verifier, address generator.
+CLI tools: **promoted to [Phase 9.5](phase-9.5-cli-tool.md)** (2026-08-01, 2026 funding window).
 
 ---
 

--- a/.specify/memory/roadmap/phase-9.5-cli-tool.md
+++ b/.specify/memory/roadmap/phase-9.5-cli-tool.md
@@ -1,0 +1,67 @@
+# Phase 9.5: Command-Line Tool
+
+**Goal**: Scriptable terminal access to the package's primitives and encodings, distributed via Homebrew  
+**Horizon**: 🟡 Next  
+**Status**: 🔜 Planned  
+**Reach**: ★★★☆☆ — developers, scripting/CI  
+**Depends On**: Phase 4 (encodings — address/npub output); Phase 6 optional (adaptor ceremonies)  
+**Funding**: Inside the 2026 funding window — Q5 (months 13–15) of the shared 2026 roadmap  
+**Last Updated**: 2026-08-01
+
+Promoted from the [backlog](backlog.md) on 2026-08-01: the deferred CLI apps (MuSig2 CLI, address generator, ECDSA signing CLI, Schnorr verifier) merge into one executable. Scheduled in the 2026 funding round as scriptable access for developers and a low-friction demo surface for the encodings and primitives shipped in year one.
+
+---
+
+## Features
+
+### Core CLI
+
+**Purpose & User Value**: Key generation, signing (ECDSA + Schnorr), verification, and address/npub encoding from the terminal — scriptable access without writing Swift.
+
+**Success Metrics**:
+- One CLI executable with keygen / sign / verify / encode subcommands
+- Address and npub output matches the Phase 4 encoding vectors
+- Zero runtime dependencies maintained (Constitution)
+
+### MuSig2 Ceremony Mode
+
+**Purpose & User Value**: Command-line MuSig2 ceremony for scripting (the backlog's medium-priority item): key aggregation, nonce exchange, partial signing, aggregation.
+
+**Success Metrics**:
+- Ceremony state export/import between steps, so scripts can drive each stage
+- Matches the existing MuSig2 test vectors
+
+### Homebrew Formula
+
+**Purpose & User Value**: `brew install` distribution — the demo surface for the year's shipped primitives.
+
+**Success Metrics**:
+- Formula published in a tap; `brew install` produces a working binary on macOS
+- Versioned releases track package tags
+
+---
+
+## Phase Dependencies & Sequencing
+
+1. **Core CLI** — after Phase 4 encodings (address/npub output)
+2. **MuSig2 ceremony mode** — rides shipped MuSig2; adaptor flows optional after Phase 6
+3. **Homebrew formula** — with the first tagged CLI release
+
+---
+
+## Phase-Specific Metrics
+
+| Metric | Target |
+|--------|--------|
+| Homebrew install → working binary | Pass on macOS |
+| Encoding output vs Phase 4 vectors | 100% match |
+| External dependencies added | 0 |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Key material on a CLI | Misuse for real funds | Clear warnings; documented test-usage patterns (Constitution III) |
+| Scope creep into wallet territory | Delay | Primitives + encodings only; no chain or wallet logic |


### PR DESCRIPTION
- Promote CLI tools from backlog to Phase 9.5 (Q5 scheduled)
- Add vendir migration to high-priority items (Q1)
- Annotate funding window: Phases 3/8/9 outside, Phase 10 Silent Payments inside
- Add new phase-9.5-cli-tool.md with Homebrew distribution plan
- Update backlog.md to reflect CLI promotion